### PR TITLE
docs: redesign as OpenClaw evolution, not reinvention

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,69 +2,94 @@
 
 > *The last employee you'll ever hire.*
 
-Kubernetes-native AI agent runtime for Discord. Define an agent in YAML — personality, tools, memory. Deploy with Helm. It scales.
+OpenClaw, evolved for Kubernetes. Persistent state, horizontal scaling, Helm charts.
 
 ## What
 
-Automate-E runs AI agents on Kubernetes that talk to users on Discord. Agents have:
+Automate-E extends [OpenClaw](https://github.com/openclaw/openclaw) — the open-source agent runtime powering Pi-E, Volt-E, Review-E, and iBuild-E — with Kubernetes-native persistence and scaling. Everything OpenClaw does, Automate-E does. Plus:
 
-- **Persistent personality** — character files define who the agent is
-- **Long-term memory** — conversations, facts, and patterns in Postgres
-- **Tool use** — agents call your HTTP APIs via LLM function calling
-- **Horizontal scaling** — gateway receives events, workers process them, KEDA auto-scales
-- **Pod resilience** — all state in Postgres + Redis, pods restart without losing anything
+- **State survives pod restarts** — sessions, memory, and facts persisted in Postgres + Redis
+- **Horizontal scaling** — gateway receives Discord events, workers process them, KEDA auto-scales
+- **Deploy with Helm** — `helm install book-e automate-e/agent -f agent.yaml`
+- **Same config format** — `openclaw.json` + `SOUL.md` work unchanged
+
+## Why Not Just Run OpenClaw on k8s?
+
+You can. But:
+
+| Problem | What Happens |
+|---|---|
+| Pod restarts | All sessions, memory, and context lost (in-memory only) |
+| Node maintenance | Agent goes down, no failover |
+| Scaling | Single process, can't handle concurrent load |
+| Gateway bind | `"lan"` mode breaks in Docker/k8s networking |
+
+Automate-E solves these by adding a persistence layer and a queue-based architecture on top of OpenClaw.
 
 ## Architecture
 
+### Phase 1 (Now) — OpenClaw + Postgres
+
 ```
-Discord ──websocket──> Gateway (StatefulSet, 1 shard/pod)
-                            │
-                       BullMQ (Redis)
-                            │
-                      ┌─────┼─────┐
-                      ▼     ▼     ▼
-                 Worker  Worker  Worker   ◀── KEDA auto-scales
-                      │     │     │
-                      ▼     ▼     ▼
-                 Postgres (memory)
-                 Your APIs (tools)
+Discord ──> OpenClaw pod (1 replica)
+                │
+           Postgres (sessions, memory, facts)
+           External APIs (tools)
+```
+
+Single pod, same as today's OpenClaw, but with Postgres-backed memory instead of in-memory. Pod restarts don't lose state.
+
+### Phase 2 (Planned) — Gateway + Workers
+
+```
+Discord ──> Gateway (StatefulSet, 1 shard/pod)
+                │
+           BullMQ (Redis)
+                │
+          ┌─────┼─────┐
+          ▼     ▼     ▼
+     Worker  Worker  Worker   ◀── KEDA auto-scales
+          │     │     │
+          ▼     ▼     ▼
+     Postgres + Redis
+     External APIs
 ```
 
 ## Quick Start
 
-```yaml
-# book-e.yaml — an AI accountant
-name: Book-E
-personality: |
-  Norwegian accounting assistant. Precise with numbers.
-  Processes receipts, registers invoices, answers questions.
-discord:
-  channels: ["#invoices"]
-tools:
-  - url: http://accountant-api:8080
-    endpoints:
-      - POST /receipt/attach
-      - POST /invoice/register
-      - GET /folio/balance
-llm:
-  primary: gemini-2.5-flash
-  fallback: claude-haiku
-```
-
 ```bash
-helm install book-e automate-e/agent -f book-e.yaml
+# Deploy Book-E (AI Accountant) on k3s
+helm install book-e automate-e/agent \
+  --set-file soul=SOUL.md \
+  --set-file config=openclaw.json \
+  --set discord.tokenSecret=book-e-secrets \
+  --set llm.apiKeySecret=book-e-secrets
 ```
 
-## Status
+## First Agent: Book-E
 
-**Phase 1** (in progress): Simple single-replica bot for [AI Accountant](https://github.com/Stig-Johnny/ai-accountant).
+Book-E is an AI accounting assistant for Invotek AS. It processes receipts, registers invoices, and answers accounting questions on Discord. Defined entirely in config — no code.
 
-**Phase 2** (planned): Gateway + worker split, BullMQ, KEDA auto-scaling, Helm chart.
+- **SOUL.md** — Norwegian accounting personality
+- **openclaw.json** — Discord #invoices channel, Claude Haiku, tool endpoints
+- **Deploys on** — `ghcr.io/stig-johnny/automate-e` with config mounted as ConfigMap
+
+See [Stig-Johnny/ai-accountant](https://github.com/Stig-Johnny/ai-accountant) for the agent config.
 
 ## Docs
 
-- [Architecture](docs/architecture.md) — system design, memory model, scaling
-- [Research](docs/research.md) — competitive analysis of 35+ products
+- [Architecture](docs/architecture.md) — how Automate-E extends OpenClaw for k8s
+- [Research](docs/research.md) — competitive analysis, what we learn from 35+ products
+
+## Status
+
+- [x] Research and architecture design
+- [ ] Phase 1: OpenClaw + Postgres persistence adapter
+- [ ] Phase 1: Helm chart
+- [ ] Phase 1: Book-E deployed on k3s
+- [ ] Phase 2: Gateway + Worker split
+- [ ] Phase 2: BullMQ + KEDA auto-scaling
+- [ ] Phase 3: Agent CRD, multi-agent platform
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,111 +4,227 @@ title: Architecture — Automate-E
 
 # Architecture
 
-## Overview
+## Core Idea
+
+Automate-E is **OpenClaw, evolved for Kubernetes.** Not a new agent framework — an extension that makes OpenClaw's battle-tested agent model work in k8s where pods are ephemeral, workloads scale horizontally, and state must survive restarts.
+
+## What OpenClaw Already Does Well
+
+OpenClaw is the production agent runtime powering Pi-E, Volt-E, Review-E, and iBuild-E. It handles:
+
+| Capability | How OpenClaw Does It |
+|---|---|
+| **Personality** | SOUL.md — identity, guardrails, communication style |
+| **Discord** | Native WebSocket gateway, per-channel config, mention handling, thread sessions |
+| **Tools** | MCP tool profiles (fs, shell, cron, web, memory, browser) with deny-lists |
+| **Memory** | Built-in `memory_search()` / `memory_set()` via MCP |
+| **Model failover** | Primary + fallbacks, automatic retry on 529 |
+| **Security** | 3-layer: Tailscale ACL + Docker iptables + tool deny-lists |
+| **Session management** | Per-thread sessions with idle timeout |
+| **Configuration** | `openclaw.json` — model, tools, channels, sandbox, gateway |
+
+**We don't rebuild any of this.** We inherit it.
+
+## What OpenClaw Lacks for Kubernetes
+
+| Gap | Problem | Automate-E Solution |
+|---|---|---|
+| **In-memory sessions** | Pod restart = lost state | Postgres + Redis persistence layer |
+| **Single-process** | Can't scale, can't survive eviction | Gateway + Worker split |
+| **No HPA** | Fixed resource allocation | KEDA auto-scaling on queue depth |
+| **Docker-only deploy** | Manual `docker run` on bare metal | Helm chart, ArgoCD, k8s-native |
+| **No shared state** | Each agent instance is isolated | Shared Postgres for multi-replica workers |
+| **Gateway bind issues** | `lan` mode breaks in Docker, cron fails | k8s Service networking, no bind hacks |
+
+## Architecture: OpenClaw + k8s Persistence Layer
 
 ```
-Discord ──websocket──> Gateway (StatefulSet, 1 shard/pod)
-                            │
-                       BullMQ (Redis)
-                            │
-                      ┌─────┼─────┐
-                      ▼     ▼     ▼
-                 Worker  Worker  Worker   ◀── KEDA auto-scales
-                      │     │     │
-                      ▼     ▼     ▼
-                 Postgres (memory)    Your APIs (tools)
+                    ┌─────────────────────────────────┐
+                    │         Discord Gateway           │
+                    │                                   │
+                    │  OpenClaw (mostly unchanged)       │
+                    │  - Discord WebSocket connection    │
+                    │  - Session routing                 │
+                    │  - SOUL.md personality             │
+                    │  - openclaw.json config            │
+                    │                                   │
+                    │  CHANGED: writes events to queue   │
+                    │  instead of processing in-process  │
+                    └──────────────┬────────────────────┘
+                                   │
+                              BullMQ (Redis)
+                                   │
+                    ┌──────────────┼──────────────┐
+                    ▼              ▼              ▼
+              ┌──────────┐  ┌──────────┐  ┌──────────┐
+              │ Worker 1 │  │ Worker 2 │  │ Worker 3 │  ← KEDA
+              │          │  │          │  │          │
+              │ Claude   │  │ Claude   │  │ Claude   │
+              │ MCP tools│  │ MCP tools│  │ MCP tools│
+              │ Memory   │  │ Memory   │  │ Memory   │
+              └────┬─────┘  └────┬─────┘  └────┬─────┘
+                   │             │             │
+                   ▼             ▼             ▼
+              ┌──────────────────────────────────────┐
+              │  Persistence Layer (NEW)               │
+              │                                        │
+              │  Redis: hot memory, active sessions     │
+              │  Postgres + pgvector: conversations,    │
+              │    facts, patterns, archival             │
+              └──────────────────────────────────────┘
 ```
 
-## Components
+## What Changes in OpenClaw
 
-### Gateway (StatefulSet)
-- 1 pod per Discord shard (1 shard for <1000 guilds)
-- Discord WebSocket → BullMQ queue. Replies from queue → Discord.
-- No LLM, no business logic. ~32MB RAM.
-- **Has:** Discord bot token, Redis credentials
-- **Does NOT have:** LLM keys, API secrets, DB credentials
+Automate-E does NOT fork or rewrite OpenClaw. It wraps it with a persistence adapter and a queue layer:
 
-### Workers (Deployment + HPA)
-- 1-N replicas, auto-scaled by KEDA based on queue depth
-- Picks jobs from BullMQ → loads character + memory → calls LLM with tools → writes reply
-- Fully stateless — can restart, move, scale
-- **Has:** LLM API key, Postgres credentials, Redis credentials
-- **Does NOT have:** Discord bot token, backend API secrets
+### 1. Persistence Adapter
 
-### Redis
-- BullMQ job/reply queues
-- Hot memory (active session context)
-- KEDA scaler source
+Replace OpenClaw's in-memory `memory_search`/`memory_set` with a Postgres-backed implementation:
 
-### Postgres + pgvector
-- Conversations, memory, facts, patterns, processing history, character configs
-
-### External APIs (Tools)
-- HTTP endpoints defined in character config
-- Workers call via standard HTTP
-- Backend authenticates with its own k8s secrets
-
-## Character File
-
-```json
-{
-  "name": "Book-E",
-  "bio": "AI accounting assistant for Invotek AS",
-  "personality": "Precise, helpful, speaks Norwegian.",
-  "lore": ["Folio for banking", "Fiken for accounting", "25% MVA standard"],
-  "style": { "language": "Norwegian", "tone": "professional but friendly" },
-  "messageExamples": [
-    { "user": "Forward: Adobe invoice 199kr",
-      "agent": "Adobe 199 kr → konto 6540 (programvare, 25% MVA). Lagt til på Folio." }
-  ],
-  "tools": [{
-    "url": "http://accountant-api:8080",
-    "endpoints": [
-      { "method": "POST", "path": "/receipt/attach" },
-      { "method": "POST", "path": "/invoice/register" },
-      { "method": "GET", "path": "/folio/balance" }
-    ]
-  }],
-  "discord": { "channels": ["#invoices"], "threadMode": "per-document" },
-  "memory": { "conversationRetention": "30d", "patternRetention": "indefinite" },
-  "llm": { "primary": "gemini-2.5-flash", "fallback": "claude-haiku" }
-}
+```
+OpenClaw memory_set("user_prefers_6540", "...")
+  ↓
+Automate-E adapter
+  ↓
+INSERT INTO facts (agent, user_id, key, value) VALUES (...)
 ```
 
-## Memory (3-tier, inspired by Letta/MemGPT)
+Same MCP tool interface. OpenClaw doesn't know the difference. Sessions, conversations, and facts survive pod restarts.
 
-| Tier | Store | Latency | Content | Retention |
-|------|-------|---------|---------|-----------|
-| **Core** | Redis | <1ms | Active session, working memory | Session |
-| **Recall** | Postgres + pgvector | ~5ms | Conversation history, embeddings | 30 days |
-| **Archival** | Postgres | ~10ms | Patterns, facts, processing history | Indefinite |
+### 2. Queue Layer (Phase 2)
 
-**Observational Memory** (from Mastra): Raw messages compressed into observations ("User prefers account 6540 for software"). Injected into context instead of replaying full history. ~90% token reduction.
+Split the Discord gateway from the agent processing:
 
-**Fact Extraction** (from Mem0): Atomic facts after each conversation: `{merchant: "Adobe", account: 6540, vat: 25}`. Scoped per user, agent, company.
+- **Gateway pod** (StatefulSet, 1 replica): OpenClaw's Discord WebSocket, but instead of processing messages in-process, writes them to BullMQ
+- **Worker pods** (Deployment, 1-N replicas): OpenClaw agent loop + MCP tools, picks up from queue, writes reply back
 
-## Scaling
+Phase 1 runs as a single pod (like today's OpenClaw). Phase 2 adds the split.
+
+### 3. Helm Chart
+
+Package everything as a Helm chart:
+
+```bash
+helm install book-e automate-e/agent \
+  --set character.file=character.json \
+  --set soul.file=SOUL.md \
+  --set discord.token=<from-secret> \
+  --set llm.apiKey=<from-secret>
+```
+
+The chart creates:
+- ConfigMap from SOUL.md + character config
+- Deployment (Phase 1) or StatefulSet + Deployment (Phase 2)
+- SealedSecret references
+- Optional: Redis, KEDA ScaledObject
+
+## Agent Configuration
+
+Automate-E agents use the same config files as OpenClaw:
+
+### openclaw.json — Runtime Config
+Model, tools, Discord channels, sandbox, gateway. **Unchanged from OpenClaw format.** Any existing openclaw.json works.
+
+### SOUL.md — Personality & Operating Rules
+Identity, guardrails, communication style, rate limits. **Unchanged from OpenClaw format.** Book-E's SOUL.md defines its accounting personality.
+
+### character.json — Automate-E Extension (Optional)
+Additional config for Automate-E-specific features not in openclaw.json:
+- HTTP tool endpoints (typed API calls)
+- Memory retention settings
+- Observational memory config
+- Message examples for few-shot prompting
+
+This is additive — OpenClaw agents that don't use these features don't need this file.
+
+## Memory Architecture
+
+Three tiers, extending OpenClaw's `memory_search`/`memory_set`:
+
+| Tier | Store | OpenClaw Equivalent | What Changes |
+|------|-------|---|---|
+| **Hot** | Redis | In-memory session state | Moved to Redis (survives restart) |
+| **Warm** | Postgres + pgvector | `memory_search()` / `memory_set()` | Backed by Postgres instead of in-memory |
+| **Cold** | Postgres archival | Not available in OpenClaw | NEW: long-term patterns, processing history, 5yr retention |
+
+### Observational Memory (NEW)
+
+After conversations, extract compressed observations:
+- "User prefers account 6540 for software purchases"
+- "Adobe invoices are always 199 kr/month"
+
+Injected into context instead of replaying full history. ~90% token reduction for long-running agents.
+
+## Security Model
+
+Inherits OpenClaw's 3-layer security and adds k8s-native isolation:
+
+| Layer | OpenClaw | Automate-E |
+|---|---|---|
+| **Network** | Tailscale ACL + Docker iptables | k8s NetworkPolicy |
+| **Tools** | MCP tool profiles + deny-lists | Same (unchanged) |
+| **Secrets** | Environment variables in Docker | k8s SealedSecrets, RBAC |
+| **Agent isolation** | Separate Docker containers | Separate pods, namespaces |
+
+**Secret isolation principle (from AI Accountant docs):** The agent pod has Discord + LLM keys only. Backend API keys (Folio, Fiken, Postgres) live in the API pod. Compromising the agent doesn't expose financial data.
+
+## Scaling Model
+
+| Phase | Replicas | How |
+|---|---|---|
+| **Phase 1** | 1 pod | Single OpenClaw instance with Postgres persistence |
+| **Phase 2** | 1 gateway + N workers | Gateway StatefulSet + Worker Deployment + BullMQ + KEDA |
+
+KEDA ScaledObject watches BullMQ queue depth in Redis:
 
 | Queue depth | Workers |
-|-------------|---------|
+|---|---|
 | 0 | 1 (minimum) |
 | > 5 | 2 |
 | > 20 | 3 |
 | > 50 | 5 (maximum) |
 
-KEDA ScaledObject watches BullMQ queue depth in Redis.
-
-## Secret Isolation
-
-| Secret | Gateway | Worker | Backend API |
-|--------|---------|--------|-------------|
-| Discord bot token | Yes | No | No |
-| LLM API key | No | Yes | No |
-| Postgres creds | No | Yes | Yes |
-| Redis creds | Yes | Yes | No |
-| Folio/Fiken keys | No | No | Yes |
-
 ## Phases
 
-**Phase 1 (now):** Single Deployment, 1 replica. discord.js + Claude SDK + Postgres.
-**Phase 2 (later):** Gateway + Worker + Redis + BullMQ + KEDA. Same character file, transparent upgrade.
+### Phase 1: OpenClaw + Postgres (Now)
+
+- Run OpenClaw as-is on k8s (single pod)
+- Add Postgres persistence adapter for memory
+- SOUL.md + openclaw.json mounted as ConfigMaps
+- Helm chart for deployment
+- Book-E as first agent
+
+### Phase 2: Gateway + Worker Split
+
+- Extract Discord gateway into StatefulSet
+- BullMQ queue between gateway and workers
+- Worker Deployment with HPA/KEDA
+- Redis for hot state + queue
+
+### Phase 3: Multi-Agent Platform
+
+- Multiple agents on the same cluster
+- Shared Postgres, separate Redis namespaces
+- Agent CRD (inspired by kagent)
+- `automate-e agent create book-e -f agent.yaml`
+
+## Relationship to OpenClaw
+
+```
+OpenClaw (open source)
+  │
+  ├── Used directly by: Pi-E, Volt-E, Review-E, iBuild-E
+  │   (Docker on bare metal / VPS)
+  │
+  └── Extended by: Automate-E
+      │
+      ├── Adds: Postgres persistence, k8s deployment, Helm chart
+      ├── Adds: Gateway+worker split, HPA scaling
+      ├── Adds: Observational memory, cold archival
+      │
+      └── First agent: Book-E (AI Accountant)
+          (k8s on Dell k3s cluster)
+```
+
+Automate-E is a **superset** of OpenClaw. Every OpenClaw feature works. Automate-E adds k8s-native persistence and scaling on top. When these features mature, they can be contributed back upstream.

--- a/docs/research.md
+++ b/docs/research.md
@@ -4,99 +4,114 @@ title: Competitive Research — Automate-E
 
 # Competitive Research
 
-Research across 35+ products in 6 categories. **No single product combines all six capabilities we need**: character personality + Discord-native + Kubernetes-native + multi-replica scaling + persistent memory + function calling.
+## Starting Point: OpenClaw
 
-## OpenClaw vs Automate-E
+Automate-E is not built from scratch. It extends [OpenClaw](https://github.com/openclaw/openclaw), the open-source agent runtime already powering Pi-E, Volt-E, Review-E, and iBuild-E in production.
 
-OpenClaw is the existing agent runner used by Pi-E, Volt-E, iBuild-E, and other agents in the Dashecorp fleet. Here's how it compares to Automate-E:
+### What OpenClaw Has
 
-| Capability | OpenClaw | Automate-E |
-|---|---|---|
-| **Purpose** | Run Claude Code CLI sessions | Run AI agents with character + tools |
-| **Discord** | Native (channel per agent) | Native (channel per agent) |
-| **LLM** | Claude (via Claude Code) | Any (Vercel AI SDK — Claude, Gemini, etc.) |
-| **Memory** | Session-based (ephemeral) | Persistent (Postgres — conversations, facts, patterns) |
-| **Personality** | System prompt in openclaw.json | Structured character file (ElizaOS-compatible) |
-| **Tool use** | MCP servers | HTTP API endpoints (defined in character config) |
-| **Scaling** | Single process per agent | Gateway + N workers (KEDA auto-scaling) |
-| **Pod restarts** | Loses session state | State survives (Postgres + Redis) |
-| **Architecture** | Monolithic (bot + LLM + tools in one process) | Split (gateway + workers + memory) |
-| **K8s native** | Runs on k8s but not designed for it | Built for k8s from day one |
-| **Use case** | Interactive coding assistant | Autonomous task agent (accounting, support, etc.) |
+| Feature | Implementation |
+|---|---|
+| **Personality** | SOUL.md — identity, guardrails, style, rate limits |
+| **Discord** | Native WebSocket gateway, per-channel config, mention handling, sessions |
+| **Telegram** | Native, with pairing and DM policies |
+| **Tools** | MCP profiles: fs, shell, cron, memory, web, browser. Deny-list security model |
+| **Memory** | `memory_search()` / `memory_set()` MCP tools (in-memory) |
+| **Model failover** | Primary + fallbacks, auto-retry on 529 |
+| **Security** | 3-layer: network (Tailscale/iptables) + tools (deny-list) + config (sandbox) |
+| **Sessions** | Per-thread, idle timeout, history limit |
+| **Config** | `openclaw.json` — one file for everything |
+| **Auth** | OAuth (Claude Max) or API key |
+| **Deployment** | Docker container per agent on bare metal/VPS |
 
-**Key difference:** OpenClaw is an interactive coding agent — it runs Claude Code sessions. Automate-E is a task automation agent — it has a persistent character, remembers conversations, and autonomously processes documents using tool calling. OpenClaw's agents lose context on restart; Automate-E's agents pick up where they left off.
+### What OpenClaw Lacks
 
-**Not a replacement:** OpenClaw and Automate-E serve different purposes. OpenClaw is for coding tasks (iBuild-E building iOS apps). Automate-E is for business automation (Book-E processing invoices). Both run on the same k3s cluster.
+| Gap | Impact |
+|---|---|
+| In-memory state only | Pod restart = all sessions, memory, and context lost |
+| Single-process architecture | Cannot scale horizontally, single point of failure |
+| No k8s support | Manual Docker deploy, no Helm, no ArgoCD, no HPA |
+| No shared state | Each agent instance is fully isolated |
+| Docker networking issues | `gateway.bind: "lan"` breaks cron in Docker |
+| No long-term archival | No 5-year retention, no observational memory |
 
-## The Gap
+## Competitive Landscape
 
-| Capability | ElizaOS | Mastra | LangGraph | CrewAI | kagent | **Automate-E** |
+Research across 35+ products. Key finding: **no product combines OpenClaw's agent model with Kubernetes-native scaling and persistent state.**
+
+### OpenClaw vs Everything Else
+
+| | OpenClaw | ElizaOS | Mastra | LangGraph | kagent | **Automate-E** |
 |---|---|---|---|---|---|---|
-| Character/Personality | Yes | No | No | Partial | No | **Yes** |
-| Discord Native | Plugin | No | No | No | No | **Yes** |
-| K8s Native | No | No | No | No | Yes | **Yes** |
-| Multi-Replica Scaling | No | No | Commercial | No | Yes | **Yes** |
-| Persistent Memory | Basic | Good | Checkpoint | 4-layer | No | **Yes** |
-| Function Calling | Actions | Tools | Tools | Tools | MCP | **Yes** |
+| Battle-tested agents | **Yes** (4 in prod) | Community | No agents in prod | Enterprise | DevOps only | **Yes** (inherits) |
+| Personality (SOUL.md) | **Yes** | Character JSON | Prompt only | Prompt only | No | **Yes** (inherits) |
+| Discord native | **Yes** | Plugin | No | No | No | **Yes** (inherits) |
+| MCP tools | **Yes** | Plugin actions | Zod tools | LangChain tools | MCP | **Yes** (inherits) |
+| Model failover | **Yes** | Config | Vercel AI SDK | LangChain | Config | **Yes** (inherits) |
+| Security layers | **3-layer** | Basic | None | None | RBAC | **3-layer** (inherits + k8s) |
+| Persistent memory | In-memory | Postgres | Postgres | Postgres | None | **Postgres** (new) |
+| K8s native | No | No | No | No | **Yes** | **Yes** (new) |
+| Multi-replica | No | No | No | Commercial | Yes | **Yes** (new) |
+| Helm chart | No | No | No | No | Yes | **Yes** (new) |
+| Pod restart resilience | No | No | Yes | Yes | Yes | **Yes** (new) |
 
-## Key Findings by Category
+### Key Insight
 
-### Character Frameworks
-- **ElizaOS** (17.8k stars, MIT): De facto standard for character files. Plugin architecture. Native Discord. But single-process, no k8s.
-- **Letta/MemGPT** (15k stars, Apache-2.0): Best memory model — 3-tier (core/recall/archival) inspired by OS architecture. Agents edit own memory.
-- **SillyTavern** (43k stars, AGPL): World Info for lore injection. Universal LLM backend switching.
+Every other framework would require us to rebuild what OpenClaw already does (Discord, tools, sessions, security). Automate-E avoids that by extending OpenClaw with the pieces it's missing.
 
-### Agent Orchestration
-- **Mastra** (22k stars, Apache-2.0): Best observational memory — compressed reflections reduce tokens ~90%.
-- **LangGraph** (44.6k stars, MIT): Checkpoint-per-step. Used by LinkedIn, Uber, Klarna.
-- **Flowise** (50.9k stars, Apache-2.0): **Dual-mode deployment** — simple (SQLite) for dev, BullMQ+Redis for production scaling. Directly relevant pattern.
-- **Dify** (129.8k stars): Low barrier to entry drives adoption. Docker Compose first.
+## What We Learn From Other Products
 
-### Discord on Kubernetes
-- **Kubecord**: **The reference architecture.** Gateway → NATS → Workers → Redis. Shards as separate pods. Exactly the pattern we need.
-- **Marver**: K8s StatefulSet autoscaler using Discord's recommended shard count.
-- **discord-hybrid-sharding**: 40-60% resource reduction vs standard sharding.
+### From ElizaOS: Character File Format
+ElizaOS character JSON (name, bio, lore, style, message examples) is the community standard for AI character definition. We should support this format alongside SOUL.md for agents that need structured personality beyond free-form markdown.
 
-### K8s-Native AI
-- **kagent** (817 stars, Apache-2.0, CNCF): Agent CRDs (Agent, ModelConfig, RemoteMCPServer). First k8s-native agent framework.
-- **Agent Sandbox** (kubernetes-sigs): Warm pools for <1s cold start. Suspension/resumption. Official k8s SIG project.
-- **KServe/Seldon/Ray**: ML serving patterns — CRDs, scale-to-zero, vertical-before-horizontal scaling.
+### From Letta/MemGPT: Memory Hierarchy
+Three-tier memory model (Core/Recall/Archival) inspired by OS architecture. Agents edit their own memory using tools. We apply this to OpenClaw's `memory_search`/`memory_set`:
+- **Core** = Redis (hot, active session) — replaces OpenClaw's in-memory
+- **Recall** = Postgres + pgvector (warm, searchable history)
+- **Archival** = Postgres (cold, 5-year retention)
 
-### Memory Systems
-- **Mem0** (50.6k stars): Atomic fact extraction. 26% accuracy over OpenAI Memory. 91% faster. 90% fewer tokens.
-- **Zep/Graphiti**: Temporal knowledge graph — facts have periods of validity.
-- **Motorhead** (Rust): Dead simple — 3 endpoints. Incremental summarization.
+### From Mastra: Observational Memory
+Compressed reflections stored separately from raw messages. "User prefers account 6540 for software." Reduces token costs ~90%. We add this as a post-conversation extraction step.
 
-### Message Queues
-- **BullMQ**: Proven by Flowise for horizontal scaling. KEDA integration. TypeScript native.
-- **NATS JetStream**: Used by Kubecord. Lightweight. Built-in service discovery.
-- **Postgres LISTEN/NOTIFY**: **Does NOT scale** — global mutex bottleneck.
-- **Redis Streams**: Middle ground. Consumer groups + replay. KEDA support.
+### From Mem0: Atomic Fact Extraction
+Extract `{user, fact, confidence}` tuples after conversations. Scoped per user, agent, company. 26% accuracy improvement over stuffing raw context.
 
-## Technology Decisions
+### From Kubecord: Gateway + Worker Pattern
+The reference architecture for Discord bots on k8s. Gateway (StatefulSet) → NATS/Redis → Workers (Deployment). We adopt this for Phase 2, using BullMQ instead of NATS (TypeScript native, KEDA integration).
+
+### From Flowise: Dual-Mode Deployment
+Simple mode (SQLite, single process) for dev, production mode (Postgres + Redis + BullMQ) for scaling. Users start simple, graduate to distributed. We apply this: Phase 1 is single-pod OpenClaw with Postgres, Phase 2 adds the split.
+
+### From kagent: Agent CRD
+K8s custom resource definitions for agents. `kubectl apply -f agent.yaml` creates a running agent. We adopt this pattern for Phase 3.
+
+### From Agent Sandbox (k8s-sigs): Warm Pools
+Pre-warmed pods for <1s cold start. Suspension/resumption for idle agents. We adopt this for cost efficiency when running many agents.
+
+## Technology Choices
 
 | Component | Choice | Rationale |
-|-----------|--------|-----------|
-| Language | TypeScript | ElizaOS, Mastra, Flowise all TS. Largest Discord ecosystem. |
-| Discord Gateway | StatefulSet, 1 shard/pod | Kubecord pattern. Stable identity. |
-| Event Bus | BullMQ (Redis) | Proven by Flowise. KEDA integration. TypeScript native. |
-| Memory — Hot | Redis | Sub-ms working memory. |
-| Memory — Warm | Postgres + pgvector | Searchable history with embeddings. |
-| Memory — Cold | Postgres archival | Long-term, 5yr retention. |
-| Character Format | ElizaOS-compatible JSON | De facto standard. |
-| Agent CRD | Inspired by kagent + agent-sandbox | K8s-native declarative. |
-| Autoscaling | KEDA + HPA | Event-driven based on queue depth. |
-| LLM | Vercel AI SDK | Multi-provider (Claude, Gemini, OpenAI). |
+|---|---|---|
+| **Runtime base** | OpenClaw (Node.js/TypeScript) | Battle-tested, 4 agents in production |
+| **Persistence** | Postgres + pgvector | OpenClaw memory_set → Postgres adapter |
+| **Hot state** | Redis | Session state + BullMQ queue |
+| **Queue** | BullMQ | Proven by Flowise, KEDA integration, TypeScript |
+| **Discord** | OpenClaw native | Already works, don't rebuild |
+| **Tools** | OpenClaw MCP | Already works, don't rebuild |
+| **Personality** | SOUL.md (OpenClaw) + character.json (optional) | Inherit what works, extend where needed |
+| **Autoscaling** | KEDA | Event-driven scaling on queue depth |
+| **Deployment** | Helm chart | k8s-native, ArgoCD-compatible |
+| **Agent definition** | CRD (Phase 3) | Inspired by kagent |
 
 ## Sources
 
-Key references (full list in research agent output):
-- [Kubecord](https://github.com/kubecord/Kubecord) — k8s Discord architecture
-- [ElizaOS](https://github.com/elizaOS/eliza) — character file standard
-- [Letta](https://github.com/letta-ai/letta) — memory hierarchy
-- [Mem0](https://github.com/mem0ai/mem0) — atomic memory extraction
-- [kagent](https://github.com/kagent-dev/kagent) — k8s agent CRDs
-- [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — k8s SIG
-- [Flowise](https://github.com/FlowiseAI/Flowise) — BullMQ scaling
+- [OpenClaw](https://github.com/openclaw/openclaw) — base runtime
+- [Kubecord](https://github.com/kubecord/Kubecord) — k8s Discord gateway+worker pattern
+- [ElizaOS](https://github.com/elizaOS/eliza) — character file format
+- [Letta/MemGPT](https://github.com/letta-ai/letta) — 3-tier memory hierarchy
+- [Mem0](https://github.com/mem0ai/mem0) — atomic fact extraction
 - [Mastra](https://github.com/mastra-ai/mastra) — observational memory
+- [Flowise](https://github.com/FlowiseAI/Flowise) — BullMQ dual-mode scaling
+- [kagent](https://github.com/kagent-dev/kagent) — k8s agent CRDs
+- [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) — k8s-sigs warm pools
 - [KEDA](https://keda.sh/) — event-driven autoscaling


### PR DESCRIPTION
## Summary

Major rewrite of Automate-E design based on deep research into how OpenClaw actually works.

**Before:** Automate-E was designed as a new agent framework from scratch (discord.js + Claude SDK + custom everything). This duplicated 80% of what OpenClaw already does.

**After:** Automate-E extends OpenClaw with three things it doesn't have:
1. **Persistent state** — Postgres adapter for `memory_set`/`memory_get`, Redis for sessions
2. **Horizontal scaling** — Gateway + Worker split with BullMQ + KEDA
3. **K8s-native deployment** — Helm chart, ConfigMaps, SealedSecrets, ArgoCD

Everything else (Discord, SOUL.md, MCP tools, model failover, security, sessions) is inherited from OpenClaw unchanged.

## What changes
- `docs/architecture.md` — complete rewrite showing OpenClaw extension model
- `docs/research.md` — reframed as "what we learn from competitors to add to OpenClaw"
- `README.md` — updated positioning, phases, quick start

## Test plan
- [ ] Review architecture makes sense as OpenClaw superset
- [ ] Phase progression is realistic (1 → 2 → 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)