### PR TITLE
fix: use ubuntu-latest for container builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: arc-linux-docker
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
arc-linux-docker is scoped to nutri-e. Use GitHub-hosted runner.