### PR TITLE
feat: SHA-based GitOps for Book-E deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE: ghcr.io/stig-johnny/automate-e
 
 jobs:
   build-and-push:
@@ -20,8 +21,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-tag: ${{ steps.meta.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image tag
+        id: meta
+        run: echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -36,5 +43,28 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.REGISTRY }}/stig-johnny/automate-e:latest
-            ${{ env.REGISTRY }}/stig-johnny/automate-e:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+
+  update-gitops:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ai-accountant
+        uses: actions/checkout@v4
+        with:
+          repository: Stig-Johnny/ai-accountant
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Update Book-E image tag
+        run: |
+          sed -i "s|image: ghcr.io/stig-johnny/automate-e:.*|image: ghcr.io/stig-johnny/automate-e:${{ github.sha }}|" deploy/k8s/book-e-deployment.yaml
+          cat deploy/k8s/book-e-deployment.yaml | grep "image:"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deploy/k8s/book-e-deployment.yaml
+          git diff --cached --quiet && echo "No changes" || git commit -m "chore: update Book-E image to ${{ github.sha }}"
+          git push


### PR DESCRIPTION
CI updates ai-accountant deployment manifest with image SHA after build. Requires RELEASE_PAT.