### PR TITLE
feat: expose dashboard via Cloudflare Tunnel

### DIFF
--- a/deploy/k8s/book-e-service.yaml
+++ b/deploy/k8s/book-e-service.yaml
@@ -1,0 +1,13 @@
+# Exposes Book-E dashboard for Cloudflare Tunnel access
+apiVersion: v1
+kind: Service
+metadata:
+  name: book-e
+  namespace: automate-e
+spec:
+  selector:
+    app: book-e
+  ports:
+    - name: dashboard
+      port: 3000
+      targetPort: 3000

--- a/deploy/k8s/cloudflared.yaml
+++ b/deploy/k8s/cloudflared.yaml
@@ -1,0 +1,40 @@
+# Cloudflare Tunnel connector for automate-e dashboard
+# Routes book-e.dashecorp.com → Book-E dashboard (port 3000)
+# Tunnel token stored as secret: cloudflared-automate-e-token (created manually)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: automate-e
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-automate-e-token
+                  key: token
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"


### PR DESCRIPTION
## Summary
- K8s Service exposing Book-E dashboard on port 3000
- Cloudflared deployment in `automate-e` namespace
- Tunnel routes `book-e.dashecorp.com` → dashboard
- Cloudflare Access policy restricts to `post@stigjohnny.no`

## Cloudflare resources created
- Tunnel: `automate-e-dashboard` (ID: `8ba10552-6847-4abc-9a29-4dc5bd0ce59a`)
- DNS: `book-e.dashecorp.com` CNAME → tunnel
- Access App: "Book-E Dashboard" with email policy

## Manual step required
Create the tunnel token secret on the k3s cluster:
```bash
kubectl create secret generic cloudflared-automate-e-token \
  --from-literal=token=$(curl -s -H "Authorization: Bearer <CF_TOKEN>" \
  "https://api.cloudflare.com/client/v4/accounts/59710bf016d417f860051f1f00b00258/cfd_tunnel/8ba10552-6847-4abc-9a29-4dc5bd0ce59a/token" \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['result'])") \
  -n automate-e
```

Closes #21

## Test plan
- [ ] Merge and deploy via ArgoCD
- [ ] Create k8s secret on cluster
- [ ] Visit https://book-e.dashecorp.com — should show Cloudflare Access login
- [ ] After auth, dashboard loads with live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)