### PR TITLE
fix: add imagePullSecrets for GHCR

### DIFF
--- a/deploy/k8s/book-e-deployment.yaml
+++ b/deploy/k8s/book-e-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: book-e
     spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
       containers:
         - name: book-e
           image: ghcr.io/stig-johnny/automate-e:latest


### PR DESCRIPTION
## Summary
Book-E pod fails with ImagePullBackOff — private GHCR repo needs pull secret.

## Test plan
- [ ] Pod starts after ArgoCD syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)