### PR TITLE
fix: use wss:// for WebSocket over HTTPS

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -93,7 +93,7 @@
 </div>
 
 <script>
-const wsUrl = `ws://${location.host}`;
+const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}`;
 let ws;
 let toolCallCount = 0;
 let toolErrorCount = 0;


### PR DESCRIPTION
## Summary
Dashboard WebSocket fails behind Cloudflare Tunnel because it uses `ws://` but the page is served over HTTPS. Auto-detect protocol.

## Test plan
- [ ] Dashboard at https://book-e.dashecorp.com shows live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)