### PR TITLE
feat: Helm chart for deploying agents

### DIFF
--- a/charts/automate-e/Chart.yaml
+++ b/charts/automate-e/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: automate-e
+description: Kubernetes-native AI agent runtime for Discord
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/charts/automate-e/templates/NOTES.txt
+++ b/charts/automate-e/templates/NOTES.txt
@@ -1,0 +1,18 @@
+Automate-E agent deployed: {{ .Release.Name }}
+
+{{- if .Values.dashboard.enabled }}
+
+Dashboard:
+  kubectl port-forward svc/{{ include "automate-e.fullname" . }} {{ .Values.dashboard.port }}:{{ .Values.dashboard.port }}
+  Then open http://localhost:{{ .Values.dashboard.port }}
+{{- end }}
+
+{{- if .Values.tunnel.enabled }}
+
+Tunnel: https://{{ .Values.tunnel.hostname }}
+{{- end }}
+
+{{- if not .Values.secrets.existingSecret }}
+
+Secrets created from values. For production, use existingSecret instead.
+{{- end }}

--- a/charts/automate-e/templates/_helpers.tpl
+++ b/charts/automate-e/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "automate-e.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "automate-e.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "automate-e.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "automate-e.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "automate-e.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "automate-e.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "automate-e.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- include "automate-e.fullname" . }}-secrets
+{{- end }}
+{{- end }}

--- a/charts/automate-e/templates/cloudflared.yaml
+++ b/charts/automate-e/templates/cloudflared.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.tunnel.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "automate-e.fullname" . }}-cloudflared
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tunnel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "automate-e.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tunnel
+  template:
+    metadata:
+      labels:
+        {{- include "automate-e.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: tunnel
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.tunnel.tokenSecretName }}
+                  key: token
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 10m
+            limits:
+              memory: 128Mi
+              cpu: 100m
+{{- end }}

--- a/charts/automate-e/templates/configmap.yaml
+++ b/charts/automate-e/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "automate-e.fullname" . }}-character
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+data:
+  character.json: |
+    {{- .Values.character | toJson | nindent 4 }}

--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "automate-e.fullname" . }}
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "automate-e.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "automate-e.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: agent
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: discord-bot-token
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: database-url
+            {{- if .Values.redis.enabled }}
+            - name: REDIS_URL
+              value: {{ .Values.redis.url | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: character
+              mountPath: /config
+              readOnly: true
+          {{- if .Values.dashboard.enabled }}
+          ports:
+            - name: dashboard
+              containerPort: {{ .Values.dashboard.port }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: character
+          configMap:
+            name: {{ include "automate-e.fullname" . }}-character

--- a/charts/automate-e/templates/secret.yaml
+++ b/charts/automate-e/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "automate-e.fullname" . }}-secrets
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  discord-bot-token: {{ .Values.secrets.discordBotToken | quote }}
+  anthropic-api-key: {{ .Values.secrets.anthropicApiKey | quote }}
+  database-url: {{ .Values.secrets.databaseUrl | quote }}
+{{- end }}

--- a/charts/automate-e/templates/service.yaml
+++ b/charts/automate-e/templates/service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.dashboard.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "automate-e.fullname" . }}
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "automate-e.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: dashboard
+      port: {{ .Values.dashboard.port }}
+      targetPort: {{ .Values.dashboard.port }}
+{{- end }}

--- a/charts/automate-e/values.yaml
+++ b/charts/automate-e/values.yaml
@@ -1,0 +1,40 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/stig-johnny/automate-e
+  tag: latest
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: ghcr-pull-secret
+
+# Inline character.json — the agent's personality, tools, and config
+character: {}
+
+redis:
+  enabled: false
+  url: ""
+
+dashboard:
+  enabled: true
+  port: 3000
+
+tunnel:
+  enabled: false
+  tokenSecretName: ""
+  hostname: ""
+
+# Set existingSecret to use a pre-created secret, or provide values inline
+secrets:
+  existingSecret: ""
+  discordBotToken: ""
+  anthropicApiKey: ""
+  databaseUrl: ""
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+    cpu: 500m


### PR DESCRIPTION
## Summary
- Helm chart at `charts/automate-e/` for deploying any Automate-E agent
- Supports: character ConfigMap, dashboard, Cloudflare Tunnel, existing secrets, Redis
- No Bitnami dependencies — official images only

Closes #15

## Test plan
- [ ] `helm template charts/automate-e` renders valid YAML
- [ ] `helm install` with Book-E values deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)