### PR TITLE
fix: handle thread-already-exists error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,12 +63,24 @@ client.on('messageCreate', async (message) => {
 
       await message.reply(response);
     } else {
-      const thread = message.hasThread
-        ? message.thread
-        : await message.startThread({
+      let thread;
+      if (message.hasThread) {
+        thread = message.thread;
+      } else {
+        try {
+          thread = await message.startThread({
             name: `${message.author.displayName} — ${new Date().toLocaleDateString('nb-NO')}`,
             autoArchiveDuration: 1440,
           });
+        } catch (err) {
+          if (err.code === 160004) {
+            // Thread already exists for this message — fetch it
+            thread = await message.fetch().then(m => m.thread);
+          } else {
+            throw err;
+          }
+        }
+      }
 
       await thread.sendTyping();
       dashboard.updateSession(thread.id, { user: message.author.displayName, type: 'thread' });


### PR DESCRIPTION
## Summary
When Discord returns error 160004 (thread already exists for message), fetch the existing thread instead of crashing. This happens when a message is retried or when another bot already created a thread.

## Test plan
- [ ] Send message in #invoices — Book-E creates thread and replies
- [ ] Retry same message — Book-E uses existing thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)