### PR TITLE
fix: add ExternalName service for cross-namespace Postgres access

### DIFF
--- a/deploy/k8s/postgres-external.yaml
+++ b/deploy/k8s/postgres-external.yaml
@@ -1,0 +1,10 @@
+# ExternalName service pointing to Postgres in ai-accountant namespace
+# Allows Book-E to connect via postgres.automate-e.svc.cluster.local
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: automate-e
+spec:
+  type: ExternalName
+  externalName: postgres.ai-accountant.svc.cluster.local


### PR DESCRIPTION
## Summary
- Adds an ExternalName Service in `deploy/k8s/postgres-external.yaml` so Book-E pods in the `automate-e` namespace can reach Postgres via `postgres` hostname instead of the full FQDN `postgres.ai-accountant.svc.cluster.local`
- Reduces coupling and makes the Postgres dependency explicit in the namespace manifests

## Test plan
- [ ] Verify `kubectl apply -f deploy/k8s/postgres-external.yaml` creates the service
- [ ] Verify Book-E pod can resolve `postgres` to `postgres.ai-accountant.svc.cluster.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)