### PR TITLE
feat: switch to gateway+worker deployment

### DIFF
--- a/deploy/k8s/book-e-deployment.yaml
+++ b/deploy/k8s/book-e-deployment.yaml
@@ -1,48 +1,90 @@
+# Gateway — 1 replica (Discord allows one gateway connection per bot token)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: book-e
+  name: book-e-gateway
   namespace: automate-e
   labels:
-    app: book-e
+    app: book-e-gateway
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: book-e
+      app: book-e-gateway
   template:
     metadata:
       labels:
-        app: book-e
+        app: book-e-gateway
     spec:
       imagePullSecrets:
         - name: ghcr-pull-secret
       containers:
-        - name: book-e
+        - name: gateway
           image: ghcr.io/stig-johnny/automate-e:latest
           imagePullPolicy: Always
+          command: ["node", "src/gateway.js"]
           env:
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: book-e-secrets
                   key: discord-bot-token
+            - name: REDIS_URL
+              value: "redis://redis.automate-e.svc.cluster.local:6379"
+          volumeMounts:
+            - name: character
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: character
+          configMap:
+            name: book-e-character
+---
+# Workers — 2 replicas, scalable. Process messages from Redis queue.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: book-e-worker
+  namespace: automate-e
+  labels:
+    app: book-e-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: book-e-worker
+  template:
+    metadata:
+      labels:
+        app: book-e-worker
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      containers:
+        - name: worker
+          image: ghcr.io/stig-johnny/automate-e:latest
+          imagePullPolicy: Always
+          command: ["node", "src/worker.js"]
+          env:
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: book-e-secrets
                   key: anthropic-api-key
-            - name: ACCOUNTING_API_URL
-              value: "http://ai-accountant-api.ai-accountant.svc.cluster.local"
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
                   name: book-e-secrets
                   key: database-url
-            # Optional: set REDIS_URL to enable gateway/worker split mode
-            # When set, deploy separate gateway + worker pods instead of this single deployment
-            # - name: REDIS_URL
-            #   value: "redis://redis.automate-e.svc.cluster.local:6379"
+            - name: REDIS_URL
+              value: "redis://redis.automate-e.svc.cluster.local:6379"
           volumeMounts:
             - name: character
               mountPath: /config


### PR DESCRIPTION
## Summary
Replace single-process Book-E with gateway (1 replica) + worker (2 replicas) via Redis streams.

- Gateway handles Discord connection, publishes messages to Redis
- Workers process messages with Claude API, publish replies back
- ArgoCD prunes old `book-e` deployment, creates `book-e-gateway` + `book-e-worker`

## Test plan
- [x] Tested manually — gateway published, worker processed, reply delivered to Discord
- [ ] ArgoCD syncs and creates correct pods
- [ ] Send message on Discord — single reply (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)