### PR TITLE
fix: single worker to prevent duplicate replies

### DIFF
--- a/deploy/k8s/book-e-deployment.yaml
+++ b/deploy/k8s/book-e-deployment.yaml
@@ -47,7 +47,8 @@ spec:
           configMap:
             name: book-e-character
 ---
-# Workers — 2 replicas, scalable. Process messages from Redis queue.
+# Workers — process messages from Redis queue.
+# TODO: Fix consumer group race condition before scaling to 2+ replicas.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -56,7 +57,7 @@ metadata:
   labels:
     app: book-e-worker
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: book-e-worker


### PR DESCRIPTION
Reduces workers to 1 until Redis consumer group race is fixed. Creates issue for the multi-replica fix.