### PR TITLE
fix: worker sends replies directly via Discord REST API

### DIFF
--- a/deploy/k8s/book-e-deployment.yaml
+++ b/deploy/k8s/book-e-deployment.yaml
@@ -74,6 +74,11 @@ spec:
           imagePullPolicy: Always
           command: ["node", "src/worker.js"]
           env:
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: book-e-secrets
+                  key: discord-bot-token
             - name: ANTHROPIC_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -9,7 +9,6 @@ import Redis from 'ioredis';
 import { loadCharacter } from './character.js';
 
 const STREAM_MESSAGES = 'automate-e:messages';
-const STREAM_REPLIES = 'automate-e:replies';
 const MAX_STREAM_LEN = 10000;
 const recentMessageIds = new Set();
 
@@ -23,10 +22,7 @@ if (!redisUrl) {
 }
 
 const redis = new Redis(redisUrl);
-const redisSub = new Redis(redisUrl);
-
 redis.on('error', (err) => console.error('[Gateway] Redis error:', err.message));
-redisSub.on('error', (err) => console.error('[Gateway] Redis sub error:', err.message));
 
 // --- Discord client ---
 const client = new Client({
@@ -43,7 +39,6 @@ const client = new Client({
 client.once('ready', () => {
   console.log(`[Gateway] Logged in as ${client.user.tag}`);
   console.log(`[Gateway] Listening on channels: ${character.discord.channels.join(', ')}`);
-  listenForReplies();
 });
 
 // --- Publish incoming messages to Redis stream ---
@@ -108,69 +103,6 @@ client.on('messageCreate', async (message) => {
   );
 });
 
-// --- Listen for worker replies on Redis stream ---
-async function listenForReplies() {
-  try {
-    await redisSub.xgroup('CREATE', STREAM_REPLIES, 'gateway', '$', 'MKSTREAM');
-  } catch (err) {
-    if (!err.message.includes('BUSYGROUP')) throw err;
-  }
-
-  const consumerId = `gateway-${process.pid}`;
-
-  async function pollReplies() {
-    try {
-      const results = await redisSub.xreadgroup(
-        'GROUP', 'gateway', consumerId,
-        'COUNT', 10,
-        'BLOCK', 2000,
-        'STREAMS', STREAM_REPLIES, '>',
-      );
-
-      if (results) {
-        for (const [, entries] of results) {
-          for (const [id, fields] of entries) {
-            try {
-              const reply = JSON.parse(fields[1]);
-              console.log(`[Gateway] Delivering reply entry ${id} to ${reply.threadId}`);
-              await deliverReply(reply);
-            } catch (err) {
-              console.error('[Gateway] Failed to deliver reply:', err.message);
-            }
-            await redisSub.xack(STREAM_REPLIES, 'gateway', id);
-          }
-        }
-      }
-    } catch (err) {
-      console.error('[Gateway] Reply listener error:', err.message);
-    }
-    // Yield to event loop, then poll again
-    setTimeout(pollReplies, 100);
-  }
-
-  pollReplies();
-}
-
-async function deliverReply(reply) {
-  const { threadId, content, isDM } = reply;
-
-  if (isDM) {
-    const userId = threadId.replace('dm-', '');
-    const user = await client.users.fetch(userId);
-    const dmChannel = await user.createDM();
-    await dmChannel.send(content);
-  } else {
-    const channel = await client.channels.fetch(threadId);
-    if (channel) {
-      await channel.send(content);
-    } else {
-      console.error(`[Gateway] Could not find channel ${threadId}`);
-    }
-  }
-
-  console.log(`[Gateway] Delivered reply to ${threadId}`);
-}
-
 // --- Graceful shutdown ---
 let shuttingDown = false;
 for (const signal of ['SIGTERM', 'SIGINT']) {
@@ -180,7 +112,6 @@ for (const signal of ['SIGTERM', 'SIGINT']) {
     console.log(`[Gateway] ${signal} received, shutting down...`);
     client.destroy();
     redis.disconnect();
-    redisSub.disconnect();
     process.exit(0);
   });
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -90,15 +90,8 @@ while (!shuttingDown) {
             attachments: msg.attachments || [],
           }, dashboard);
 
-          const reply = {
-            threadId: msg.threadId,
-            content: response,
-            isDM: msg.isDM,
-          };
-
-          await redis.xadd(STREAM_REPLIES, 'MAXLEN', '~', MAX_STREAM_LEN, '*',
-            'payload', JSON.stringify(reply),
-          );
+          // Send reply directly via Discord REST API
+          await sendDiscordReply(msg.threadId, response, msg.isDM);
 
           await redis.xack(STREAM_MESSAGES, GROUP_NAME, id);
           console.log(`[Worker] Replied to ${msg.threadId} (acked ${id})`);
@@ -118,3 +111,30 @@ while (!shuttingDown) {
 console.log('[Worker] Shutdown complete');
 redis.disconnect();
 process.exit(0);
+
+// Send reply directly via Discord REST API (no gateway round-trip)
+const DISCORD_TOKEN = process.env.DISCORD_BOT_TOKEN;
+async function sendDiscordReply(threadId, content, isDM) {
+  let channelId = threadId;
+  if (isDM) {
+    // Create DM channel first
+    const dmRes = await fetch('https://discord.com/api/v10/users/@me/channels', {
+      method: 'POST',
+      headers: { Authorization: `Bot ${DISCORD_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipient_id: threadId.replace('dm-', '') }),
+    });
+    const dm = await dmRes.json();
+    channelId = dm.id;
+  }
+
+  const res = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+    method: 'POST',
+    headers: { Authorization: `Bot ${DISCORD_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Discord API ${res.status}: ${err}`);
+  }
+}


### PR DESCRIPTION
Eliminates duplicate replies by having workers post directly to Discord instead of round-tripping through the gateway reply stream.