### PR TITLE
chore: remove debug, scale workers to 2

### DIFF
--- a/deploy/k8s/book-e-deployment.yaml
+++ b/deploy/k8s/book-e-deployment.yaml
@@ -47,8 +47,7 @@ spec:
           configMap:
             name: book-e-character
 ---
-# Workers — process messages from Redis queue.
-# TODO: Fix consumer group race condition before scaling to 2+ replicas.
+# Workers — 2 replicas, scalable. Process messages from Redis queue.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,7 +56,7 @@ metadata:
   labels:
     app: book-e-worker
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: book-e-worker

--- a/src/worker.js
+++ b/src/worker.js
@@ -115,11 +115,7 @@ while (!shuttingDown) {
           }, dashboard);
 
           // Send reply directly via Discord REST API
-          const replyId = `reply-${Date.now()}`;
-          const taggedResponse = `${response}\n\n_[${replyId}]_`;
-          console.log(`[Worker] Sending Discord reply ${replyId} to ${msg.threadId} (${response.length} chars)`);
-          await sendDiscordReply(msg.threadId, taggedResponse, msg.isDM);
-          console.log(`[Worker] Discord reply ${replyId} sent successfully`);
+          await sendDiscordReply(msg.threadId, response, msg.isDM);
 
           await redis.xack(STREAM_MESSAGES, GROUP_NAME, id);
           console.log(`[Worker] Replied to ${msg.threadId} (acked ${id})`);


### PR DESCRIPTION
Root cause found: old book-e pod in ai-accountant namespace. Safe to scale.