### PR TITLE
feat: Helm chart with gateway+worker mode

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- if eq .Values.mode "single" }}
+# Single-process mode: one deployment handles Discord + agent loop
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,7 +7,7 @@ metadata:
   labels:
     {{- include "automate-e.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "automate-e.selectorLabels" . | nindent 6 }}
@@ -38,10 +40,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}
                   key: database-url
-            {{- if .Values.redis.enabled }}
-            - name: REDIS_URL
-              value: {{ .Values.redis.url | quote }}
-            {{- end }}
           volumeMounts:
             - name: character
               mountPath: /config
@@ -57,3 +55,115 @@ spec:
         - name: character
           configMap:
             name: {{ include "automate-e.fullname" . }}-character
+{{- else }}
+# Gateway+Worker mode: gateway handles Discord, workers process messages via Redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "automate-e.fullname" . }}-gateway
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "automate-e.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        {{- include "automate-e.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: gateway
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["node", "src/gateway.js"]
+          env:
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: discord-bot-token
+            - name: REDIS_URL
+              value: {{ .Values.redis.url | quote }}
+          volumeMounts:
+            - name: character
+              mountPath: /config
+              readOnly: true
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: character
+          configMap:
+            name: {{ include "automate-e.fullname" . }}-character
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "automate-e.fullname" . }}-worker
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.workers.replicas }}
+  selector:
+    matchLabels:
+      {{- include "automate-e.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "automate-e.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["node", "src/worker.js"]
+          env:
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: discord-bot-token
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: database-url
+            - name: REDIS_URL
+              value: {{ .Values.redis.url | quote }}
+          volumeMounts:
+            - name: character
+              mountPath: /config
+              readOnly: true
+          {{- if .Values.dashboard.enabled }}
+          ports:
+            - name: dashboard
+              containerPort: {{ .Values.dashboard.port }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: character
+          configMap:
+            name: {{ include "automate-e.fullname" . }}-character
+{{- end }}

--- a/charts/automate-e/templates/redis.yaml
+++ b/charts/automate-e/templates/redis.yaml
@@ -1,0 +1,65 @@
+{{- if and .Values.redis.enabled .Values.redis.deploy }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "automate-e.fullname" . }}-redis
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "automate-e.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "automate-e.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "automate-e.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          args: ["--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+              cpu: 200m
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.redis.storageClass }}
+        storageClassName: {{ .Values.redis.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "automate-e.fullname" . }}-redis
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    {{- include "automate-e.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  clusterIP: None
+{{- end }}

--- a/charts/automate-e/values.yaml
+++ b/charts/automate-e/values.yaml
@@ -1,19 +1,28 @@
-replicaCount: 1
+# Single-process mode (default) or gateway+worker mode (set redis.enabled: true)
+mode: single  # "single" or "split"
 
 image:
   repository: ghcr.io/stig-johnny/automate-e
   tag: latest
   pullPolicy: Always
 
-imagePullSecrets:
-  - name: ghcr-pull-secret
+imagePullSecrets: []
 
 # Inline character.json — the agent's personality, tools, and config
 character: {}
 
+# Gateway+worker mode: enable Redis for message queue
 redis:
   enabled: false
   url: ""
+  # Deploy a Redis instance alongside the agent
+  deploy: false
+  storage: 1Gi
+  storageClass: ""
+
+# Worker replicas (only used in split mode)
+workers:
+  replicas: 2
 
 dashboard:
   enabled: true
@@ -24,7 +33,7 @@ tunnel:
   tokenSecretName: ""
   hostname: ""
 
-# Set existingSecret to use a pre-created secret, or provide values inline
+# Use existingSecret to reference a pre-created secret, or provide values inline
 secrets:
   existingSecret: ""
   discordBotToken: ""

--- a/examples/book-e/values.yaml
+++ b/examples/book-e/values.yaml
@@ -1,0 +1,124 @@
+mode: split
+image:
+  repository: ghcr.io/stig-johnny/automate-e
+  tag: latest
+  pullPolicy: Always
+imagePullSecrets:
+- name: ghcr-pull-secret
+character:
+  name: Book-E
+  bio: AI accounting assistant for Invotek AS
+  personality: 'You are Book-E, an AI accounting assistant for Invotek AS, a Norwegian
+    company.
+
+    You process receipts, register invoices, and answer accounting questions.
+
+    You speak Norwegian unless the user writes in English.
+
+    You are precise with numbers and always include currency formatting (kr).
+
+    When uncertain, you ask for clarification rather than guessing.
+
+    You know Norwegian bookkeeping rules (bokføringsloven).
+
+
+    IMPORTANT: When processing receipts, invoices, or expenses, you PROPOSE actions
+    via the Event Store API. Tell the user what you proposed and whether it was auto-approved
+    or pending review.
+
+
+    You can also check costs and spending on AI services via the Cost API.'
+  lore:
+  - Folio is the business banking system — use Accounting API for transactions, receipts,
+    balance
+  - Fiken is the accounting system — use Accounting API for invoices, expenses, journal
+    entries
+  - When a receipt is attached in Folio, it automatically syncs to Fiken
+  - 25% MVA is standard, 15% for food/restaurants, 12% for transport, 0% for exports
+  - Bokføringsloven requires 5-year retention for accounting records
+  - 'All write actions go through Event Store API: PROPOSED → APPROVED → EXECUTED'
+  - Known merchants with high confidence (>90%) are auto-approved
+  - Unknown merchants require review by Review-E or a human before execution
+  - Cost API tracks spending on Anthropic, Google, and Cloudflare services
+  tools:
+  - url: http://eventstore-api.ai-accountant.svc.cluster.local
+    endpoints:
+    - method: POST
+      path: /propose/receipt
+      description: Propose receipt attachment
+    - method: POST
+      path: /propose/invoice
+      description: Propose invoice registration
+    - method: POST
+      path: /propose/expense
+      description: Propose expense registration
+    - method: GET
+      path: /events
+      description: List events by status or correlationId
+  - url: http://accounting-api.ai-accountant.svc.cluster.local
+    endpoints:
+    - method: GET
+      path: /folio/balance
+      description: Get Folio account balances
+    - method: GET
+      path: /folio/transactions
+      description: List Folio transactions
+    - method: GET
+      path: /folio/missing-receipts
+      description: Transactions missing receipts
+    - method: GET
+      path: /fiken/invoices
+      description: List Fiken invoices
+    - method: GET
+      path: /fiken/expenses
+      description: List Fiken expenses
+  - url: http://cost-api.ai-accountant.svc.cluster.local
+    endpoints:
+    - method: GET
+      path: /usage/summary
+      description: Total spending across all services
+    - method: GET
+      path: /usage/anthropic
+      description: Anthropic API usage and costs
+    - method: GET
+      path: /usage/cloudflare
+      description: Cloudflare usage and costs
+  discord:
+    channels:
+    - '#invoices'
+    threadMode: per-document
+    allowBots:
+    - '1477267530946187305'
+  memory:
+    conversationRetention: 30d
+    patternRetention: indefinite
+    historyRetention: 5y
+  llm:
+    provider: anthropic
+    model: claude-haiku-4-5-20251001
+    temperature: 0.3
+redis:
+  enabled: true
+  url: redis://book-e-automate-e-redis:6379
+  deploy: true
+  storage: 1Gi
+  storageClass: nfs-csi
+workers:
+  replicas: 2
+dashboard:
+  enabled: true
+  port: 3000
+tunnel:
+  enabled: true
+  tokenSecretName: cloudflared-automate-e-token
+  hostname: book-e.dashecorp.com
+secrets:
+  existingSecret: book-e-secrets
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+


### PR DESCRIPTION
## Summary
- Chart supports `mode: single` and `mode: split` (gateway+worker via Redis)
- Split mode: 1 gateway + N workers + optional Redis StatefulSet
- `examples/book-e/values.yaml` for production deployment
- No Bitnami dependencies

## Test plan
- [x] `helm template` renders correctly
- [ ] ArgoCD deploys Book-E via Helm
- [ ] Book-E responds on Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)