### PR TITLE
docs: rewrite docs to match running production system

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,15 @@ title: Architecture
 
 How the Automate-E runtime turns a `character.json` into a running Discord agent.
 
-## Component Overview
+## Deployment Modes
+
+### Single-process mode
+
+`index.js` runs everything in one process: Discord gateway, agent loop, memory, dashboard.
 
 ```mermaid
 graph TB
-    subgraph "Automate-E Runtime"
+    subgraph "Single Process (index.js)"
         CL[Character Loader<br/>character.js]
         DG[Discord Gateway<br/>discord.js]
         AL[Agent Loop<br/>agent.js]
@@ -32,7 +36,35 @@ graph TB
     UT --> DB
 ```
 
-## Startup Sequence
+### Split mode (gateway + workers)
+
+In production, the system runs as separate processes connected by Redis Streams.
+
+- **gateway.js** (1 replica) -- connects to Discord, publishes messages to the `automate-e:messages` Redis Stream
+- **worker.js** (N replicas) -- consumes messages via a Redis consumer group, runs the agent loop, sends replies directly via Discord REST API
+
+```mermaid
+graph LR
+    DC[Discord] <--> GW[gateway.js<br/>1 replica]
+    GW -->|XADD| RS[Redis Stream<br/>automate-e:messages]
+    RS -->|XREADGROUP| W1[worker.js<br/>replica 1]
+    RS -->|XREADGROUP| W2[worker.js<br/>replica 2]
+    W1 -->|REST API| DC
+    W2 -->|REST API| DC
+    W1 <--> CL[Claude API]
+    W2 <--> CL
+    W1 <--> MEM[Memory<br/>Postgres]
+    W2 <--> MEM
+```
+
+Key details of split mode:
+
+- **Redis consumer group** (`workers`) ensures each message is delivered to exactly one worker
+- **Redis SETNX lock** (`lock:<stream-id>`, 300s TTL) prevents duplicate processing if a message is redelivered
+- **Workers send replies directly** via Discord REST API -- there is no reply stream back through the gateway
+- **Gateway** handles thread creation and typing indicators before publishing
+
+## Startup Sequence (single-process)
 
 ```mermaid
 sequenceDiagram
@@ -73,6 +105,8 @@ flowchart TD
     TEXT --> SAVE[Save messages<br/>to memory]
     SAVE --> REPLY[Post reply<br/>in Discord thread]
 ```
+
+In split mode, the gateway handles filtering and thread creation, then publishes to Redis. The worker handles everything from LOAD onward and sends the reply via Discord REST API.
 
 ## Key Design Decisions
 
@@ -116,7 +150,9 @@ The memory system has three layers:
 ```
 automate-e/
   src/
-    index.js          # Entry point, startup orchestration
+    index.js          # Single-process entry point
+    gateway.js        # Split mode: Discord gateway, publishes to Redis Stream
+    worker.js         # Split mode: consumes from Redis, runs agent, replies via REST
     character.js      # Loads and validates character.json
     agent.js          # Agent loop, tool dispatch, prompt building
     memory.js         # Postgres + in-memory storage
@@ -124,6 +160,8 @@ automate-e/
     dashboard/
       server.js       # HTTP server + WebSocket
       index.html      # Dashboard UI
+  charts/
+    automate-e/       # Helm chart
   Dockerfile
   package.json
 ```

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,15 +27,30 @@ The dashboard runs on port 3000 by default (configurable via `DASHBOARD_PORT`).
 npm start
 ```
 
-### Kubernetes with Cloudflare Tunnel
+### Production (Cloudflare Tunnel)
 
-In production, expose the dashboard via a Cloudflare Tunnel rather than a public LoadBalancer:
+In production, expose the dashboard via a Cloudflare Tunnel. The Book-E dashboard is available at:
 
-```bash
-cloudflared tunnel --url http://book-e.ai-accountant.svc.cluster.local:3000
+```
+https://book-e.dashecorp.com
 ```
 
-Or configure a persistent tunnel in Cloudflare Zero Trust to route a subdomain (e.g., `dashboard.example.com`) to the dashboard service.
+Enable the tunnel in Helm values:
+
+```yaml
+tunnel:
+  enabled: true
+  tokenSecretName: cloudflared-automate-e-token
+  hostname: book-e.dashecorp.com
+```
+
+This deploys a `cloudflared` sidecar container that routes traffic from the public hostname to the dashboard service inside the cluster. The tunnel token is stored as a Kubernetes secret created manually before deployment.
+
+### Ad-hoc access via port-forward
+
+```bash
+kubectl port-forward -n automate-e deploy/book-e 3000:3000
+```
 
 ## WebSocket Protocol
 
@@ -73,10 +88,6 @@ sequenceDiagram
 
 The dashboard has no built-in authentication. In production:
 
-- Do not expose the dashboard port via a public Service or Ingress
 - Use Cloudflare Tunnel with Cloudflare Access for authentication
-- Or use `kubectl port-forward` for ad-hoc access:
-
-```bash
-kubectl port-forward -n ai-accountant deploy/book-e 3000:3000
-```
+- Do not expose the dashboard port via a public Service or Ingress
+- The Helm chart's tunnel integration handles this automatically when enabled

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,156 +4,173 @@ title: Deployment
 
 # Deployment
 
-Automate-E agents deploy to Kubernetes as Deployments with ConfigMap-mounted character files.
+Automate-E supports two deployment modes via its Helm chart (`charts/automate-e/`).
+
+## Deployment Modes
+
+### Single-process mode
+
+One pod runs `index.js`, which handles the Discord gateway, agent loop, and dashboard. Simple to operate, suitable for low traffic.
+
+### Gateway + worker mode (production)
+
+Set `mode: split` and enable Redis. The gateway pod connects to Discord and publishes messages to a Redis Stream. Worker pods consume messages via a consumer group and send replies directly through the Discord REST API. A Redis SETNX lock prevents duplicate processing.
+
+## Helm Chart
+
+The Helm chart is the primary deployment method. It lives in `charts/automate-e/`.
+
+### Single-process values.yaml
+
+```yaml
+mode: single
+
+image:
+  repository: ghcr.io/stig-johnny/automate-e
+  tag: latest
+
+secrets:
+  existingSecret: book-e-secrets
+
+character:
+  name: Book-E
+  bio: "AI accounting assistant"
+  # ... full character.json contents
+
+dashboard:
+  enabled: true
+  port: 3000
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 50m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+```
+
+### Gateway + worker values.yaml (production)
+
+```yaml
+mode: split
+
+image:
+  repository: ghcr.io/stig-johnny/automate-e
+  tag: latest
+
+secrets:
+  existingSecret: book-e-secrets
+
+redis:
+  enabled: true
+  deploy: true
+  storage: 1Gi
+  storageClass: nfs-csi
+
+workers:
+  replicas: 2
+
+character:
+  name: Book-E
+  bio: "AI accounting assistant"
+  # ... full character.json contents
+
+dashboard:
+  enabled: true
+  port: 3000
+
+tunnel:
+  enabled: true
+  tokenSecretName: cloudflared-automate-e-token
+  hostname: book-e.dashecorp.com
+```
 
 ## Namespace
 
-All AI Accountant resources live in the `ai-accountant` namespace:
+All resources deploy to the `automate-e` namespace:
 
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ai-accountant
+```bash
+kubectl create namespace automate-e
 ```
 
 ## Secrets
 
-Each agent needs a Discord bot token and an Anthropic API key. Use SealedSecrets for GitOps-safe storage:
+Create secrets manually before deploying. The chart references them via `secrets.existingSecret`:
 
-```yaml
-apiVersion: bitnami.com/v1
-kind: SealedSecret
-metadata:
-  name: book-e-secrets
-  namespace: ai-accountant
-spec:
-  encryptedData:
-    discord-bot-token: <sealed>
-    anthropic-api-key: <sealed>
+```bash
+# Agent secrets (Discord token + Anthropic key + optional DB URL)
+kubectl create secret generic book-e-secrets \
+  -n automate-e \
+  --from-literal=discord-bot-token=<token> \
+  --from-literal=anthropic-api-key=<key> \
+  --from-literal=database-url=<url>
+
+# GHCR pull secret (for private images)
+kubectl create secret docker-registry ghcr-pull-secret \
+  -n automate-e \
+  --docker-server=ghcr.io \
+  --docker-username=<user> \
+  --docker-password=<pat>
+
+# Cloudflare Tunnel token (if using tunnel)
+kubectl create secret generic cloudflared-automate-e-token \
+  -n automate-e \
+  --from-literal=token=<tunnel-token>
 ```
 
-For Postgres-backed memory, add a database URL secret:
-
-```yaml
-apiVersion: bitnami.com/v1
-kind: SealedSecret
-metadata:
-  name: book-e-db
-  namespace: ai-accountant
-spec:
-  encryptedData:
-    database-url: <sealed>
-```
-
-## ConfigMap
-
-Mount the character file as a ConfigMap:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: book-e-character
-  namespace: ai-accountant
-data:
-  character.json: |
-    {
-      "name": "Book-E",
-      "bio": "AI accounting assistant",
-      ...
-    }
-```
-
-## Deployment
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: book-e
-  namespace: ai-accountant
-  labels:
-    app: book-e
-    runtime: automate-e
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: book-e
-  template:
-    metadata:
-      labels:
-        app: book-e
-        runtime: automate-e
-    spec:
-      imagePullSecrets:
-        - name: ghcr-pull-secret
-      containers:
-        - name: book-e
-          image: ghcr.io/stig-johnny/automate-e:<sha>
-          env:
-            - name: CHARACTER_FILE
-              value: /config/character.json
-            - name: DISCORD_BOT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: book-e-secrets
-                  key: discord-bot-token
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: book-e-secrets
-                  key: anthropic-api-key
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: book-e-db
-                  key: database-url
-          volumeMounts:
-            - name: character
-              mountPath: /config
-              readOnly: true
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "50m"
-            limits:
-              memory: "256Mi"
-              cpu: "500m"
-      volumes:
-        - name: character
-          configMap:
-            name: book-e-character
-```
-
-!!! note
-    Always use 1 replica. Multiple replicas would create duplicate Discord responses.
+Do not use SealedSecrets. Secrets are created manually and referenced by name.
 
 ## ArgoCD
 
-The k8s manifests in `deploy/k8s/` are synced by ArgoCD from the `ai-accountant` repo:
+ArgoCD syncs the Helm chart directly from the automate-e repo:
 
 ```yaml
-source:
-  repoURL: https://github.com/Stig-Johnny/ai-accountant.git
-  targetRevision: HEAD
-  path: deploy/k8s
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: automate-e
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Stig-Johnny/automate-e.git
+    targetRevision: HEAD
+    path: charts/automate-e
+    helm:
+      valueFiles:
+        - ../../examples/book-e/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: automate-e
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
 ```
 
-Image tags use git SHAs. When the `automate-e` repo CI builds a new image, it updates `book-e-deployment.yaml` in the `ai-accountant` repo, triggering an ArgoCD sync.
+Image tags use git SHAs. CI builds push new images to GHCR, and ArgoCD detects chart or value changes on sync.
+
+## Cloudflare Tunnel
+
+The dashboard is exposed via Cloudflare Tunnel (no public LoadBalancer or Ingress). Enable it in values:
+
+```yaml
+tunnel:
+  enabled: true
+  tokenSecretName: cloudflared-automate-e-token
+  hostname: book-e.dashecorp.com
+```
+
+This deploys a `cloudflared` sidecar that routes traffic from the public hostname to the dashboard service inside the cluster.
 
 ## Adding a New Agent
 
-To deploy a second agent on the same runtime:
-
 1. Create a new `character.json` for the agent
-2. Add a ConfigMap with the character data
-3. Add a SealedSecret with the agent's Discord token and Anthropic key
-4. Add a Deployment referencing the same `ghcr.io/stig-johnny/automate-e` image
-5. Set `CHARACTER_FILE` to point to the mounted config
+2. Create a new values file referencing a new `existingSecret`
+3. Deploy as a separate Helm release in the same or different namespace
 
-Each agent runs as an independent pod with its own Discord connection and memory.
+Each agent runs independently with its own Discord connection, memory, and optional worker pool.
 
 ## Resource Guidelines
 
@@ -163,4 +180,4 @@ Each agent runs as an independent pod with its own Discord connection and memory
 | Medium (10-100/day) | 100m | 128Mi | 1000m | 512Mi |
 | High (100+/day) | 200m | 256Mi | 2000m | 1Gi |
 
-Most of the CPU is spent on HTTP calls to the Claude API (network I/O, not compute).
+Most CPU is spent on HTTP calls to the Claude API (network I/O, not compute).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@ title: Automate-E Runtime
 
 Automate-E is a Kubernetes-native AI agent runtime for Discord. It turns a `character.json` config file into a running Discord bot backed by Claude, with persistent memory, tool calling, and cost tracking.
 
+- **Repository:** [Stig-Johnny/automate-e](https://github.com/Stig-Johnny/automate-e) (public, MIT license)
+- **Documentation:** [stig-johnny.github.io/automate-e](https://stig-johnny.github.io/automate-e/)
+- **Deployment:** Helm chart in `charts/automate-e/`, deployed via ArgoCD
+
 ## Key Features
 
 | Feature | Description |
@@ -17,7 +21,8 @@ Automate-E is a Kubernetes-native AI agent runtime for Discord. It turns a `char
 | **Tool calling** | Agents call HTTP APIs defined in `character.json` |
 | **Cost tracking** | Per-model token usage and cost calculation |
 | **Live dashboard** | Real-time WebSocket dashboard for monitoring agent activity |
-| **K8s-native** | Designed to run as a Deployment with ConfigMap-mounted character files |
+| **Helm chart** | Deploy single-process or gateway+worker mode via Helm |
+| **Split mode** | Gateway + Redis Streams + workers for horizontal scaling |
 
 ## How It Works
 
@@ -44,14 +49,11 @@ sequenceDiagram
     G->>U: "Saldo: 142 350 kr"
 ```
 
-## Repository
-
-The runtime lives in [`Stig-Johnny/automate-e`](https://github.com/Stig-Johnny/automate-e) (private). Agent configurations (like Book-E) live in the consuming repo alongside their k8s manifests.
-
 ## Quick Links
 
 - [Quick Start](quickstart.md) -- run an agent locally in 5 minutes
 - [Configuration](configuration.md) -- full `character.json` reference
 - [Architecture](architecture.md) -- how the runtime works internally
-- [Deployment](deployment.md) -- deploy to Kubernetes
+- [Deployment](deployment.md) -- deploy to Kubernetes with Helm
+- [Dashboard](dashboard.md) -- real-time monitoring UI
 - [Book-E](agents/book-e.md) -- the first Automate-E agent


### PR DESCRIPTION
## Summary

- **deployment.md**: Complete rewrite. Helm chart as primary method with example values.yaml for both single-process and split modes. Replaced SealedSecrets with existingSecret pattern. Fixed namespace from ai-accountant to automate-e. Added ArgoCD Helm source config and Cloudflare Tunnel section.
- **architecture.md**: Added split mode (gateway.js + Redis Streams + worker.js) alongside existing single-process description. Documented Redis SETNX dedup lock, consumer group, and direct Discord REST API replies from workers. Updated file structure to include gateway.js and worker.js.
- **dashboard.md**: Added production URL (book-e.dashecorp.com), Cloudflare Tunnel Helm values, fixed namespace references.
- **index.md**: Added GitHub Pages docs URL, Helm chart deployment, MIT license, split mode feature. Fixed repo visibility from private to public.

## Test plan

- [ ] Verify mkdocs builds cleanly: `mkdocs build --strict`
- [ ] Confirm all internal links resolve
- [ ] Review rendered pages on GitHub Pages after merge

Generated with [Claude Code](https://claude.com/claude-code)