### PR TITLE
fix: dashboard works in gateway+worker mode

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -98,6 +98,11 @@ spec:
             - name: character
               mountPath: /config
               readOnly: true
+          {{- if .Values.dashboard.enabled }}
+          ports:
+            - name: dashboard
+              containerPort: {{ .Values.dashboard.port }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -155,11 +160,6 @@ spec:
             - name: character
               mountPath: /config
               readOnly: true
-          {{- if .Values.dashboard.enabled }}
-          ports:
-            - name: dashboard
-              containerPort: {{ .Values.dashboard.port }}
-          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/automate-e/templates/service.yaml
+++ b/charts/automate-e/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   selector:
     {{- include "automate-e.selectorLabels" . | nindent 4 }}
+    {{- if eq .Values.mode "split" }}
+    app.kubernetes.io/component: gateway
+    {{- end }}
   ports:
     - name: dashboard
       port: {{ .Values.dashboard.port }}

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -7,12 +7,14 @@
 import { Client, GatewayIntentBits, Partials, ChannelType } from 'discord.js';
 import Redis from 'ioredis';
 import { loadCharacter } from './character.js';
+import { createDashboard } from './dashboard/server.js';
 
 const STREAM_MESSAGES = 'automate-e:messages';
 const MAX_STREAM_LEN = 10000;
 const recentMessageIds = new Set();
 
 const character = loadCharacter();
+const dashboard = createDashboard(character);
 
 // --- Redis ---
 const redisUrl = process.env.REDIS_URL;
@@ -39,6 +41,7 @@ const client = new Client({
 client.once('ready', () => {
   console.log(`[Gateway] Logged in as ${client.user.tag}`);
   console.log(`[Gateway] Listening on channels: ${character.discord.channels.join(', ')}`);
+  dashboard.addLog('info', `Logged in as ${client.user.tag}`);
 });
 
 // --- Publish incoming messages to Redis stream ---
@@ -108,6 +111,8 @@ client.on('messageCreate', async (message) => {
   };
 
   console.log(`[Gateway] Publishing message from ${payload.authorName} (thread: ${threadId})`);
+  dashboard.addLog('info', `Message from ${payload.authorName}: ${payload.messageContent.slice(0, 80)}`);
+  dashboard.updateSession(threadId, { user: payload.authorName, type: isDM ? 'dm' : 'thread' });
 
   await redis.xadd(STREAM_MESSAGES, 'MAXLEN', '~', MAX_STREAM_LEN, '*',
     'payload', JSON.stringify(payload),


### PR DESCRIPTION
Dashboard now runs on the gateway pod. Service selector targets gateway in split mode.