### PR TITLE
feat: dashboard shows worker stats via Redis pub/sub

### DIFF
--- a/src/gateway.js
+++ b/src/gateway.js
@@ -26,6 +26,18 @@ if (!redisUrl) {
 const redis = new Redis(redisUrl);
 redis.on('error', (err) => console.error('[Gateway] Redis error:', err.message));
 
+// Subscribe to worker dashboard events
+const redisSub = new Redis(redisUrl);
+redisSub.on('error', (err) => console.error('[Gateway] Redis sub error:', err.message));
+redisSub.subscribe('automate-e:dashboard');
+redisSub.on('message', (channel, message) => {
+  try {
+    const event = JSON.parse(message);
+    if (event.type === 'log') dashboard.addLog(event.data.level, event.data.message);
+    if (event.type === 'toolCall') dashboard.addToolCall(event.data.name, event.data.status, event.data.latencyMs);
+  } catch {}
+});
+
 // --- Discord client ---
 const client = new Client({
   intents: [
@@ -128,6 +140,7 @@ for (const signal of ['SIGTERM', 'SIGINT']) {
     console.log(`[Gateway] ${signal} received, shutting down...`);
     client.destroy();
     redis.disconnect();
+    redisSub.disconnect();
     process.exit(0);
   });
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -22,16 +22,6 @@ const character = loadCharacter();
 const memory = await createMemory();
 const agent = createAgent(character, memory);
 
-const dashboard = {
-  addLog(level, message) {
-    console.log(`[Worker] [${level}] ${message}`);
-  },
-  addToolCall(name, status, latencyMs) {
-    console.log(`[Worker] Tool: ${name} ${status} (${latencyMs}ms)`);
-  },
-  updateSession() {},
-};
-
 // --- Redis ---
 const redisUrl = process.env.REDIS_URL;
 if (!redisUrl) {
@@ -52,6 +42,20 @@ try {
 }
 
 console.log(`[Worker] Started (consumer: ${consumerId}), character: ${character.name}`);
+
+// Publish dashboard events to Redis so gateway can display them
+const DASHBOARD_CHANNEL = 'automate-e:dashboard';
+const dashboard = {
+  addLog(level, message) {
+    console.log(`[Worker] [${level}] ${message}`);
+    redis.publish(DASHBOARD_CHANNEL, JSON.stringify({ type: 'log', data: { level, message, timestamp: new Date().toISOString() } })).catch(() => {});
+  },
+  addToolCall(name, status, latencyMs) {
+    console.log(`[Worker] Tool: ${name} ${status} (${latencyMs}ms)`);
+    redis.publish(DASHBOARD_CHANNEL, JSON.stringify({ type: 'toolCall', data: { name, status, latencyMs, timestamp: new Date().toISOString() } })).catch(() => {});
+  },
+  updateSession() {},
+};
 
 // Send reply directly via Discord REST API (no gateway round-trip)
 const DISCORD_TOKEN = process.env.DISCORD_BOT_TOKEN;


### PR DESCRIPTION
Workers publish tool calls and LLM usage to Redis. Gateway subscribes and feeds the dashboard.