### PR TITLE
docs: user-friendly rewrite with test mode first

### DIFF
--- a/docs/discord-setup.md
+++ b/docs/discord-setup.md
@@ -1,0 +1,107 @@
+---
+title: Discord Bot Setup
+---
+
+# Discord Bot Setup
+
+Detailed guide for creating and configuring a Discord bot for Automate-E.
+
+## Create the Application
+
+1. Go to [discord.com/developers/applications](https://discord.com/developers/applications)
+2. Click **New Application**
+3. Name it (e.g., "My Agent") and click Create
+
+## Get the Bot Token
+
+1. Go to the **Bot** tab in the left sidebar
+2. Click **Reset Token**
+3. Copy the token -- you'll need this as `DISCORD_BOT_TOKEN`
+4. **Never share this token or commit it to git**
+
+## Enable Required Intents
+
+Still on the **Bot** tab, scroll down to **Privileged Gateway Intents** and enable:
+
+- **Message Content Intent** -- required for the bot to read message text
+
+Without this, the bot connects but can't see what users write.
+
+## Disable Public Access
+
+To prevent random users from adding your bot to their servers:
+
+1. Go to the **Installation** tab
+2. Set **Install Link** to **None**
+3. Go back to the **Bot** tab
+4. Disable **Public Bot**
+
+## Invite to Your Server
+
+1. Go to the **OAuth2** tab
+2. In **OAuth2 URL Generator**, check the `bot` scope
+3. Under **Bot Permissions**, select:
+    - View Channels
+    - Send Messages
+    - Create Public Threads
+    - Send Messages in Threads
+    - Read Message History
+4. Copy the generated URL
+5. Open it in your browser, select your server, and authorize
+
+## Configure the Agent
+
+In your `character.json`, set the channels the bot should listen on:
+
+```json
+{
+  "discord": {
+    "channels": ["#general", "#support"]
+  }
+}
+```
+
+Channel names must match exactly, with the `#` prefix.
+
+### Thread Mode
+
+When someone sends a message in a monitored channel, the bot creates a thread for the conversation. This keeps the main channel clean and gives each conversation its own context.
+
+### DM Support
+
+The bot automatically responds to direct messages. No configuration needed.
+
+### Allow Other Bots
+
+By default, the bot ignores messages from other bots. To allow specific bots:
+
+```json
+{
+  "discord": {
+    "allowBots": ["123456789012345678"]
+  }
+}
+```
+
+Use the bot's user ID (not application ID). You can find this by enabling Developer Mode in Discord, then right-clicking the bot user.
+
+## Run the Agent
+
+```bash
+export CHARACTER_FILE=./character.json
+export DISCORD_BOT_TOKEN=your-token-here
+export ANTHROPIC_API_KEY=sk-ant-...
+
+npm start
+```
+
+You should see:
+
+```
+[Automate-E] Loaded character: My Agent
+[Automate-E] Logged in as My Agent#1234
+[Automate-E] Listening on channels: #general, #support
+[Automate-E] DMs: enabled
+```
+
+Send a message in one of the configured channels -- the bot creates a thread and responds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,11 +49,16 @@ sequenceDiagram
     G->>U: "Saldo: 142 350 kr"
 ```
 
-## Quick Links
+## Get Started
 
-- [Quick Start](quickstart.md) -- run an agent locally in 5 minutes
-- [Configuration](configuration.md) -- full `character.json` reference
+1. [Quick Start](quickstart.md) -- run an agent locally in 5 minutes (test mode, no Discord needed)
+2. [Discord Bot Setup](discord-setup.md) -- create a bot and connect to Discord
+3. [Configuration](configuration.md) -- full `character.json` reference
+
+## Learn More
+
 - [Architecture](architecture.md) -- how the runtime works internally
 - [Deployment](deployment.md) -- deploy to Kubernetes with Helm
 - [Dashboard](dashboard.md) -- real-time monitoring UI
-- [Book-E](agents/book-e.md) -- the first Automate-E agent
+- [Memory](memory.md) -- persistent conversations and facts
+- [Book-E](agents/book-e.md) -- the first Automate-E agent (AI accountant)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,80 +4,123 @@ title: Quick Start
 
 # Quick Start
 
-Get an Automate-E agent running locally in 5 minutes.
+Get an Automate-E agent running in 5 minutes. You'll start with test mode (no Discord needed), then optionally connect to Discord.
 
 ## Prerequisites
 
-- Node.js 20+
-- A Discord bot token ([Discord Developer Portal](https://discord.com/developers/applications))
-- An Anthropic API key ([console.anthropic.com](https://console.anthropic.com))
+- [Node.js 20+](https://nodejs.org/)
+- An [Anthropic API key](https://console.anthropic.com/) (free tier works)
 
-## 1. Create a Character File
+## Step 1: Clone and Install
 
-Create `character.json`:
+```bash
+git clone https://github.com/Stig-Johnny/automate-e.git
+cd automate-e
+npm install
+```
+
+## Step 2: Create Your Agent
+
+Create a file called `character.json` in the project root:
 
 ```json
 {
   "name": "My-Agent",
   "bio": "A helpful assistant",
-  "personality": "You are a helpful assistant. Be concise and accurate.",
+  "personality": "You are a helpful assistant. Answer questions clearly and concisely.",
   "lore": [
-    "You help users with general questions"
+    "You help users with general questions",
+    "You are running on the Automate-E agent runtime"
   ],
   "tools": [],
   "discord": {
     "channels": ["#general"]
   },
   "llm": {
-    "provider": "anthropic",
     "model": "claude-haiku-4-5-20251001",
-    "temperature": 0.3
+    "temperature": 0.5
   }
 }
 ```
 
-## 2. Run with Docker
+This is all you need. The `personality` field is the system prompt. `lore` adds background knowledge.
+
+## Step 3: Try It (Test Mode)
+
+Test mode gives you a web chat interface -- no Discord bot needed:
 
 ```bash
-docker run -d \
-  --name my-agent \
-  -e CHARACTER_FILE=/config/character.json \
-  -e DISCORD_BOT_TOKEN=<your-token> \
-  -e ANTHROPIC_API_KEY=<your-key> \
-  -v $(pwd)/character.json:/config/character.json:ro \
-  ghcr.io/stig-johnny/automate-e:latest
+export CHARACTER_FILE=./character.json
+export ANTHROPIC_API_KEY=sk-ant-...your-key...
+
+npm test
 ```
 
-The agent connects to Discord and starts responding in the configured channels.
+Open [http://localhost:3000](http://localhost:3000) in your browser. You'll see a chat interface with a sidebar showing token usage and logs.
 
-## 3. Run Locally (Development)
+![Test Mode](images/test-mode.png)
+
+Type a message and hit Send. Your agent responds using Claude.
+
+## Step 4: Connect to Discord (Optional)
+
+When you're ready to put your agent on Discord:
+
+### 4a. Create a Discord Bot
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application**, give it a name
+3. Go to **Bot** tab
+4. Click **Reset Token** and copy it -- this is your `DISCORD_BOT_TOKEN`
+5. Under **Privileged Gateway Intents**, enable:
+    - **Message Content Intent** (required -- the bot needs to read messages)
+6. Go to **Installation** tab, set Install Link to **None**
+7. Go back to **Bot** tab, disable **Public Bot** (only you can add it to servers)
+
+### 4b. Invite the Bot to Your Server
+
+1. Go to **OAuth2** tab
+2. Under **OAuth2 URL Generator**, select scopes: `bot`
+3. Under **Bot Permissions**, select:
+    - Send Messages
+    - Create Public Threads
+    - Send Messages in Threads
+    - Read Message History
+    - View Channels
+4. Copy the generated URL and open it in your browser
+5. Select your Discord server and authorize
+
+### 4c. Run the Agent
 
 ```bash
-git clone https://github.com/Stig-Johnny/automate-e.git
-cd automate-e
-npm install
-
 export CHARACTER_FILE=./character.json
-export DISCORD_BOT_TOKEN=<your-token>
-export ANTHROPIC_API_KEY=<your-key>
+export DISCORD_BOT_TOKEN=your-bot-token
+export ANTHROPIC_API_KEY=sk-ant-...your-key...
 
 npm start
 ```
 
-## 4. Add Tools
+The agent connects to Discord, listens on the channels defined in `character.json`, and creates a thread for each conversation.
 
-Give the agent access to HTTP APIs by adding entries to the `tools` array:
+## Step 5: Add Tools
+
+Give your agent access to any HTTP API. Add entries to the `tools` array in `character.json`:
 
 ```json
 {
   "tools": [
     {
-      "url": "http://localhost:8080",
+      "url": "https://api.example.com",
       "endpoints": [
         {
           "method": "GET",
           "path": "/weather",
-          "description": "Get current weather for a city"
+          "description": "Get current weather for a city. Pass city name as query parameter."
+        },
+        {
+          "method": "POST",
+          "path": "/notes",
+          "description": "Save a note. Send JSON body with 'title' and 'content' fields."
         }
       ]
     }
@@ -85,36 +128,59 @@ Give the agent access to HTTP APIs by adding entries to the `tools` array:
 }
 ```
 
-Claude sees these as callable tools and invokes them when relevant.
+Claude sees these as callable tools and invokes them when relevant to the conversation. Each endpoint becomes a tool the agent can use.
 
-## 5. Add Memory (Optional)
+## Step 6: Add Memory (Optional)
 
-For persistent memory across restarts, provide a Postgres connection:
+By default, conversations are stored in memory and lost on restart. For persistent memory, provide a Postgres connection:
 
 ```bash
 export DATABASE_URL=postgresql://user:pass@localhost:5432/agent
 ```
 
-Without `DATABASE_URL`, the agent uses in-memory storage (lost on restart).
+The agent stores conversations, learned facts about users, and patterns it discovers. See [Memory](memory.md) for details.
 
-## 6. Test Mode (No Discord Required)
+## Using Docker
 
-Test your agent without a Discord bot token using the built-in web chat:
+You can also run with Docker instead of Node.js directly:
 
 ```bash
-export CHARACTER_FILE=./character.json
-export ANTHROPIC_API_KEY=<your-key>
+# Test mode
+docker run --rm -p 3000:3000 \
+  -e CHARACTER_FILE=/config/character.json \
+  -e ANTHROPIC_API_KEY=sk-ant-...your-key... \
+  -v $(pwd)/character.json:/config/character.json:ro \
+  ghcr.io/stig-johnny/automate-e:latest node src/test.js
 
-npm test
-# or: node src/test.js
+# Discord mode
+docker run -d --name my-agent \
+  -e CHARACTER_FILE=/config/character.json \
+  -e DISCORD_BOT_TOKEN=your-bot-token \
+  -e ANTHROPIC_API_KEY=sk-ant-...your-key... \
+  -v $(pwd)/character.json:/config/character.json:ro \
+  ghcr.io/stig-johnny/automate-e:latest
 ```
 
-Open `http://localhost:3000` — chat with your agent directly in the browser. The sidebar shows token usage, tool calls, and logs in real-time.
+## Troubleshooting
 
-![Test Mode](images/test-mode.png)
+**"An invalid token was provided"**
+: Your Discord bot token is wrong or expired. Go to the Developer Portal, reset the token, and copy the new one.
+
+**"TokenInvalid" crash on startup**
+: This happens in `npm start` mode if the Discord token is missing. Use `npm test` for test mode without Discord.
+
+**Bot is online but doesn't respond**
+: Check that **Message Content Intent** is enabled in the Developer Portal (Bot tab). Without it, the bot can't read messages.
+
+**Bot responds in the wrong channel**
+: The `discord.channels` array in character.json must match your channel names exactly, with the `#` prefix: `["#general"]`.
+
+**"429 Too Many Requests" from Anthropic**
+: You've hit the API rate limit. Wait a minute and try again, or upgrade your Anthropic plan.
 
 ## Next Steps
 
 - [Configuration Reference](configuration.md) -- all character.json fields
-- [Deployment](deployment.md) -- deploy to Kubernetes
-- [Memory](memory.md) -- how persistent memory works
+- [Architecture](architecture.md) -- how the agent loop works
+- [Deployment](deployment.md) -- deploy to Kubernetes with Helm
+- [Dashboard](dashboard.md) -- live monitoring

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,13 +42,16 @@ markdown_extensions:
 
 nav:
   - Overview: index.md
-  - Quick Start: quickstart.md
-  - Configuration: configuration.md
-  - Architecture: architecture.md
-  - Deployment: deployment.md
-  - Dashboard: dashboard.md
-  - Memory: memory.md
-  - Usage Tracking: usage-tracking.md
+  - Getting Started:
+    - Quick Start: quickstart.md
+    - Discord Bot Setup: discord-setup.md
+    - Configuration: configuration.md
+  - Reference:
+    - Architecture: architecture.md
+    - Deployment: deployment.md
+    - Dashboard: dashboard.md
+    - Memory: memory.md
+    - Usage Tracking: usage-tracking.md
   - Agents:
     - Book-E: agents/book-e.md
 


### PR DESCRIPTION
## Summary
- Quickstart: test mode first (no Discord needed), then Discord setup
- New Discord Bot Setup page (create bot, get token, set intents, invite)
- Troubleshooting section for common errors
- Nav reorganized into Getting Started / Reference / Agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)