### PR TITLE
feat: one-shot cron mode for scheduled agents

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -166,4 +166,61 @@ spec:
         - name: character
           configMap:
             name: {{ include "automate-e.fullname" . }}-character
+{{- else if eq .Values.mode "cron" }}
+# Cron mode: runs agent once on schedule, posts results, exits
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "automate-e.fullname" . }}
+  labels:
+    {{- include "automate-e.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.cron.schedule | quote }}
+  concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.cron.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cron.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "automate-e.selectorLabels" . | nindent 12 }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: Never
+          containers:
+            - name: agent
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["node", "src/run-once.js"]
+              env:
+                - name: ANTHROPIC_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "automate-e.secretName" . }}
+                      key: anthropic-api-key
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "automate-e.secretName" . }}
+                      key: database-url
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "automate-e.secretName" . }}
+                      key: discord-webhook-url
+                      optional: true
+              volumeMounts:
+                - name: character
+                  mountPath: /config
+                  readOnly: true
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          volumes:
+            - name: character
+              configMap:
+                name: {{ include "automate-e.fullname" . }}-character
 {{- end }}

--- a/charts/automate-e/values.yaml
+++ b/charts/automate-e/values.yaml
@@ -1,5 +1,5 @@
-# Single-process mode (default) or gateway+worker mode (set redis.enabled: true)
-mode: single  # "single" or "split"
+# "single" (default), "split" (gateway+workers), or "cron" (scheduled one-shot)
+mode: single
 
 image:
   repository: ghcr.io/stig-johnny/automate-e
@@ -39,6 +39,13 @@ secrets:
   discordBotToken: ""
   anthropicApiKey: ""
   databaseUrl: ""
+
+# Cron mode settings (only used when mode: cron)
+cron:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
 
 resources:
   requests:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start:gateway": "node src/gateway.js",
     "start:worker": "node src/worker.js",
     "dev": "node --watch src/index.js",
-    "test": "node src/test.js"
+    "test": "node src/test.js",
+    "run-once": "node src/run-once.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/src/character.js
+++ b/src/character.js
@@ -50,6 +50,7 @@ export function loadCharacter() {
   character.llm.temperature = character.llm.temperature ?? 0.3;
   character.discord.allowBots = character.discord.allowBots || [];
   character.mcpServers = character.mcpServers || {};
+  character.cron = character.cron || null;
 
   console.log(`[Automate-E] Loaded character: ${character.name}`);
   return character;

--- a/src/run-once.js
+++ b/src/run-once.js
@@ -1,0 +1,82 @@
+/**
+ * One-shot mode — run a single prompt and exit.
+ * Designed for Kubernetes CronJobs (e.g., ATL-E polling PRs every 5 min).
+ *
+ * Requires: ANTHROPIC_API_KEY, CHARACTER_FILE
+ * Optional: DISCORD_WEBHOOK_URL (to post results), DATABASE_URL
+ *
+ * The prompt is read from character.cron.prompt.
+ * Results are posted to the Discord webhook if configured.
+ */
+import { loadCharacter } from './character.js';
+import { createAgent } from './agent.js';
+import { createMemory } from './memory.js';
+import { connectMcpServers } from './mcp.js';
+import { getUsageSummary } from './usage.js';
+
+const character = loadCharacter();
+
+if (!character.cron?.prompt) {
+  console.error('[Automate-E] One-shot mode requires character.cron.prompt');
+  process.exit(1);
+}
+
+const webhookUrl = process.env.DISCORD_WEBHOOK_URL || character.cron.discordWebhookUrl;
+
+console.log(`[Automate-E] One-shot mode: ${character.name}`);
+
+const memory = await createMemory();
+const mcpClients = await connectMcpServers(character.mcpServers);
+const agent = createAgent(character, memory, mcpClients);
+
+// Minimal dashboard stub for logging
+const dashboard = {
+  addLog(level, message) { console.log(`[${level}] ${message}`); },
+  addToolCall(name, status, latencyMs) { console.log(`[tool] ${name} ${status} (${latencyMs}ms)`); },
+  updateSession() {},
+  updateUsage() {},
+};
+
+try {
+  const response = await agent.process(character.cron.prompt, {
+    userId: 'cron',
+    userName: character.name,
+    channelId: 'cron',
+    threadId: `cron-${Date.now()}`,
+    attachments: [],
+  }, dashboard);
+
+  console.log(`[Automate-E] Response:\n${response}`);
+
+  // Post to Discord webhook if configured
+  if (webhookUrl && response.trim()) {
+    // Split into 2000-char chunks (Discord limit)
+    const chunks = [];
+    for (let i = 0; i < response.length; i += 2000) {
+      chunks.push(response.slice(i, i + 2000));
+    }
+
+    for (const chunk of chunks) {
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: character.name,
+          content: chunk,
+        }),
+      });
+      if (!res.ok) {
+        console.error(`[Automate-E] Discord webhook failed: ${res.status} ${await res.text()}`);
+      }
+    }
+    console.log(`[Automate-E] Posted to Discord webhook`);
+  }
+
+  console.log(`[Automate-E] ${getUsageSummary()}`);
+} catch (error) {
+  console.error(`[Automate-E] Fatal: ${error.message}`);
+  process.exitCode = 1;
+} finally {
+  await mcpClients.close();
+  await memory.close?.();
+}


### PR DESCRIPTION
Closes #64

## Summary
- New `src/run-once.js` entry point: load character → connect MCP → run one prompt → post to Discord webhook → exit
- Helm chart `mode: cron` generates a CronJob instead of Deployment
- K8s handles scheduling, retries, concurrency — no cron logic in Automate-E

## New character.json fields
```json
{
  "cron": {
    "prompt": "Check all open PRs and notify about stale handoffs."
  }
}
```

## Helm values
```yaml
mode: cron
cron:
  schedule: "*/5 * * * *"
  concurrencyPolicy: Forbid
```

## Use case
Migrate ATL-E from custom TypeScript (state machine + rule engine + GitHub polling) to:
- Automate-E runtime + GitHub MCP server + Haiku
- ~$0.60/month at 5-min intervals
- Eliminates ~2000 lines of custom code

## Test plan
- [ ] Local test with `node src/run-once.js`
- [ ] Deploy as K8s CronJob
- [ ] Verify Discord webhook output

🤖 Generated with [Claude Code](https://claude.com/claude-code)