### PR TITLE
feat: cron can coexist with single/split mode

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -166,14 +166,17 @@ spec:
         - name: character
           configMap:
             name: {{ include "automate-e.fullname" . }}-character
-{{- else if eq .Values.mode "cron" }}
-# Cron mode: runs agent once on schedule, posts results, exits
+{{- end }}
+---
+{{- if .Values.cron.enabled }}
+# Cron: runs agent prompt on schedule (can coexist with single/split Discord bot)
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "automate-e.fullname" . }}
+  name: {{ include "automate-e.fullname" . }}-cron
   labels:
     {{- include "automate-e.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cron
 spec:
   schedule: {{ .Values.cron.schedule | quote }}
   concurrencyPolicy: {{ .Values.cron.concurrencyPolicy }}
@@ -185,6 +188,7 @@ spec:
         metadata:
           labels:
             {{- include "automate-e.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: cron
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
@@ -207,6 +211,7 @@ spec:
                     secretKeyRef:
                       name: {{ include "automate-e.secretName" . }}
                       key: database-url
+                      optional: true
                 - name: DISCORD_WEBHOOK_URL
                   valueFrom:
                     secretKeyRef:

--- a/charts/automate-e/values.yaml
+++ b/charts/automate-e/values.yaml
@@ -1,4 +1,4 @@
-# "single" (default), "split" (gateway+workers), or "cron" (scheduled one-shot)
+# "single" (default) or "split" (gateway+workers)
 mode: single
 
 image:
@@ -40,8 +40,10 @@ secrets:
   anthropicApiKey: ""
   databaseUrl: ""
 
-# Cron mode settings (only used when mode: cron)
+# Cron: deploy an additional CronJob that runs the agent prompt on schedule.
+# Works with any mode — the CronJob shares the same character, secrets, and database.
 cron:
+  enabled: false
   schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3

--- a/src/run-once.js
+++ b/src/run-once.js
@@ -42,7 +42,7 @@ try {
     userId: 'cron',
     userName: character.name,
     channelId: 'cron',
-    threadId: `cron-${Date.now()}`,
+    threadId: 'cron',
     attachments: [],
   }, dashboard);
 


### PR DESCRIPTION
## Summary
- Change `cron` from a separate `mode` to an additive `cron.enabled: true` option
- CronJob deploys alongside the Deployment — same character, secrets, database
- ATL-E can listen on Discord AND run scheduled checks with shared memory

## Values example
```yaml
mode: single  # Discord bot
cron:
  enabled: true  # additionally run on schedule
  schedule: "*/5 * * * *"
```

## Test plan
- [x] run-once.js tested locally
- [x] Discord webhook posting verified
- [ ] Helm template renders both Deployment + CronJob

🤖 Generated with [Claude Code](https://claude.com/claude-code)