### PR TITLE
feat: add extraEnv support to Helm chart

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}
                   key: database-url
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: character
               mountPath: /config
@@ -94,6 +97,9 @@ spec:
                   key: discord-bot-token
             - name: REDIS_URL
               value: {{ .Values.redis.url | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: character
               mountPath: /config
@@ -218,6 +224,9 @@ spec:
                       name: {{ include "automate-e.secretName" . }}
                       key: discord-webhook-url
                       optional: true
+                {{- with .Values.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               volumeMounts:
                 - name: character
                   mountPath: /config

--- a/charts/automate-e/values.yaml
+++ b/charts/automate-e/values.yaml
@@ -49,6 +49,15 @@ cron:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
 
+# Extra environment variables (for MCP servers, custom integrations, etc.)
+extraEnv: []
+# Example:
+#   - name: GITHUB_PERSONAL_ACCESS_TOKEN
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: github-token
+
 resources:
   requests:
     memory: 64Mi


### PR DESCRIPTION
## Summary
Add `extraEnv` to values.yaml, injected into all container specs. Needed for MCP servers requiring API keys (e.g., GitHub MCP needs `GITHUB_PERSONAL_ACCESS_TOKEN`).

## Example
```yaml
extraEnv:
  - name: GITHUB_PERSONAL_ACCESS_TOKEN
    valueFrom:
      secretKeyRef:
        name: atl-e-secrets
        key: github-token
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)