### PR TITLE
fix: make max_tokens configurable

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -34,7 +34,7 @@ export function createAgent(character, memory, mcpClients) {
         try {
           response = await anthropic.messages.create({
             model: character.llm.model,
-            max_tokens: 1024,
+            max_tokens: character.llm.maxTokens || 4096,
             temperature: character.llm.temperature,
             system,
             tools,


### PR DESCRIPTION
Default increased from 1024 to 4096. ATL-E cron needs more tokens to check 9 repos.