### PR TITLE
docs: complete update for MCP, cron, and maxTokens

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,26 +44,27 @@ Each agent is defined by a `character.json` file and a `values.yaml` for Helm. T
 
 Tool APIs are **separate services** that the agent calls via HTTP. They are not part of the runtime — they are independent applications you build and deploy yourself. An agent with no tools still works (it just has conversations without calling APIs). When you define tools in `character.json`, the runtime converts them into Claude tool definitions, and Claude decides when to call them.
 
-### Example: Two agents on one cluster
+### Example: Three agents on one cluster
 
 ```
-Namespace: automate-e                    Namespace: example-e
+Namespace: example-e                     Namespace: atl-e
 ┌────────────────────────┐               ┌────────────────────────┐
-│ Book-E pod             │               │ Example-E pod          │
+│ Example-E pod          │               │ ATL-E pod (Deployment) │
 │ image: automate-e      │               │ image: automate-e      │
-│ config: book-e char    │               │ config: example-e char │
-│ channel: #invoices     │               │ channel: #example-e    │
-│ model: claude-haiku    │               │ model: claude-haiku    │
+│ config: example-e char │               │ config: atl-e char     │
+│ channel: #example-e    │               │ channel: #admin        │
+│ mode: single           │               │ mode: single + cron    │
 └──────────┬─────────────┘               └──────────┬─────────────┘
-           │ HTTP                                    │ HTTP
+           │ HTTP                                    │ MCP (stdio)
 ┌──────────▼─────────────┐               ┌──────────▼─────────────┐
-│ ai-accountant APIs     │               │ example-e-api          │
-│ (event store, folio,   │               │ (/quotes/random,       │
-│  fiken, cost API)      │               │  /facts/random)        │
+│ example-e-api          │               │ GitHub MCP Server      │
+│ (/quotes/random,       │               │ (list PRs, reviews,    │
+│  /facts/random)        │               │  check runs, issues)   │
 └────────────────────────┘               └────────────────────────┘
+                                         + CronJob every 5 min
 ```
 
-Both agents run the **exact same runtime image**. The only differences are the character config and which tool APIs they call.
+All agents run the **exact same runtime image**. The only differences are the character config, which tools they use (HTTP or MCP), and the deployment mode.
 
 ## Deployment Modes
 
@@ -122,6 +123,16 @@ Key details of split mode:
 - **Redis SETNX lock** (`lock:<stream-id>`, 300s TTL) prevents duplicate processing if a message is redelivered
 - **Workers send replies directly** via Discord REST API -- there is no reply stream back through the gateway
 - **Gateway** handles thread creation and typing indicators before publishing
+
+### Cron mode (scheduled one-shot)
+
+`run-once.js` runs the agent loop once with a predefined prompt, posts results to a Discord webhook, and exits. Deployed as a Kubernetes CronJob.
+
+- Can run **alongside** single or split mode (same character, same database)
+- No Discord bot connection needed -- output goes to a webhook
+- K8s handles scheduling, retries, and concurrency
+
+Use `cron.enabled: true` in Helm values to add a CronJob alongside the Discord bot.
 
 ## Startup Sequence (single-process)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,8 @@ LLM provider configuration.
   "llm": {
     "provider": "anthropic",
     "model": "claude-haiku-4-5-20251001",
-    "temperature": 0.3
+    "temperature": 0.3,
+    "maxTokens": 4096
   }
 }
 ```
@@ -221,6 +222,25 @@ LLM provider configuration.
 | `provider` | string | `"anthropic"` | LLM provider (currently only `"anthropic"`) |
 | `model` | string | `"claude-haiku-4-5-20251001"` | Model identifier |
 | `temperature` | number | `0.3` | Response randomness (0.0 = deterministic, 1.0 = creative) |
+| `maxTokens` | number | `4096` | Maximum tokens per Claude response. Increase for agents that make many tool calls per turn. |
+
+## `cron`
+
+Configuration for one-shot cron mode. When set, the agent can run on a schedule via `node src/run-once.js`, executing the prompt and posting results to a Discord webhook.
+
+```json
+{
+  "cron": {
+    "prompt": "Check all open PRs and report any that need attention."
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prompt` | string | Yes | The prompt to execute on each cron run |
+
+The cron schedule itself is configured in the Helm chart (`cron.schedule`), not in `character.json`. Results are posted to the `DISCORD_WEBHOOK_URL` environment variable if set.
 
 ## Environment Variables
 
@@ -232,6 +252,7 @@ These are set on the container, not in `character.json`.
 | `DISCORD_BOT_TOKEN` | Yes | Discord bot token |
 | `ANTHROPIC_API_KEY` | Yes | Anthropic API key |
 | `DATABASE_URL` | No | Postgres connection string. Omit for in-memory mode. |
+| `DISCORD_WEBHOOK_URL` | No | Discord webhook URL for cron mode output. |
 | `DASHBOARD_PORT` | No | Dashboard HTTP port (default: `3000`) |
 
 ## Full Example
@@ -273,10 +294,20 @@ These are set on the container, not in `character.json`.
     "patternRetention": "indefinite",
     "historyRetention": "indefinite"
   },
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  },
   "llm": {
     "provider": "anthropic",
     "model": "claude-haiku-4-5-20251001",
-    "temperature": 0.3
+    "temperature": 0.3,
+    "maxTokens": 4096
+  },
+  "cron": {
+    "prompt": "Check all open PRs and report any that need attention."
   }
 }
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -167,6 +167,42 @@ tunnel:
 
 This deploys a `cloudflared` sidecar that routes traffic from the public hostname to the dashboard service inside the cluster.
 
+## Cron Mode (Scheduled Agents)
+
+Add a CronJob alongside the Discord bot by setting `cron.enabled: true`. The CronJob runs `run-once.js` which executes the prompt from `character.cron.prompt` and posts results to a Discord webhook.
+
+```yaml
+mode: single  # Discord bot as usual
+
+cron:
+  enabled: true
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+
+# Extra env vars for MCP servers (e.g., GitHub token)
+extraEnv:
+  - name: GITHUB_PERSONAL_ACCESS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: my-agent-secrets
+        key: github-token
+```
+
+The CronJob shares the same character, secrets, and database as the Deployment. Add `discord-webhook-url` to your secret:
+
+```bash
+kubectl create secret generic my-agent-secrets \
+  -n my-namespace \
+  --from-literal=discord-bot-token=<token> \
+  --from-literal=anthropic-api-key=<key> \
+  --from-literal=discord-webhook-url=<webhook-url> \
+  --from-literal=github-token=<pat>
+```
+
+You can also run cron-only (no Discord bot) by omitting the `discord-bot-token`.
+
 ## Adding a New Agent
 
 1. Create a new `character.json` for the agent


### PR DESCRIPTION
## Fixes from doc audit

- **architecture.md**: Replace Book-E example with generic agents, add cron mode section
- **configuration.md**: Document `cron` field, `maxTokens` in LLM table, `DISCORD_WEBHOOK_URL` env var, add MCP + cron to full example
- **deployment.md**: Add cron mode deployment guide with Helm values, extraEnv, and webhook secret

No Book-E references remain. All 3 deployment modes documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)