### PR TITLE
feat: webhook receiver for real-time event ingestion

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -51,6 +51,7 @@ export function loadCharacter() {
   character.discord.allowBots = character.discord.allowBots || [];
   character.mcpServers = character.mcpServers || {};
   character.cron = character.cron || null;
+  character.webhooks = character.webhooks || {};
 
   console.log(`[Automate-E] Loaded character: ${character.name}`);
   return character;

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -21,13 +21,25 @@ const state = {
 // WebSocket clients for live updates
 const wsClients = new Set();
 
-export function createDashboard(character, memory) {
+export function createDashboard(character, memory, { webhookHandler } = {}) {
   state.character = character;
   state.memoryType = process.env.DATABASE_URL ? 'postgres' : 'in-memory';
 
   const html = readFileSync(join(__dirname, 'index.html'), 'utf-8');
 
-  const server = createServer((req, res) => {
+  const server = createServer(async (req, res) => {
+    // Webhook endpoints: POST /webhook/{source}
+    const webhookMatch = req.method === 'POST' && req.url?.match(/^\/webhook\/(\w+)/);
+    if (webhookMatch && webhookHandler) {
+      try {
+        await webhookHandler(req, res, webhookMatch[1]);
+      } catch (err) {
+        console.error('[Webhook] Error:', err.message);
+        if (!res.headersSent) { res.writeHead(500); res.end('Internal error'); }
+      }
+      return;
+    }
+
     if (req.url === '/' || req.url === '/dashboard') {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(html);

--- a/src/gateway.js
+++ b/src/gateway.js
@@ -8,13 +8,13 @@ import { Client, GatewayIntentBits, Partials, ChannelType } from 'discord.js';
 import Redis from 'ioredis';
 import { loadCharacter } from './character.js';
 import { createDashboard } from './dashboard/server.js';
+import { createWebhookHandler } from './webhook.js';
 
 const STREAM_MESSAGES = 'automate-e:messages';
 const MAX_STREAM_LEN = 10000;
 const recentMessageIds = new Set();
 
 const character = loadCharacter();
-const dashboard = createDashboard(character);
 
 // --- Redis ---
 const redisUrl = process.env.REDIS_URL;
@@ -25,6 +25,21 @@ if (!redisUrl) {
 
 const redis = new Redis(redisUrl);
 redis.on('error', (err) => console.error('[Gateway] Redis error:', err.message));
+
+// --- Webhook handler + Dashboard ---
+const webhookHandler = Object.keys(character.webhooks || {}).length > 0
+  ? createWebhookHandler(character, {
+      publishToRedis: async (payload) => {
+        console.log(`[Gateway] Publishing webhook event from ${payload.webhookSource}/${payload.webhookEvent}`);
+        dashboard.addLog('info', `Webhook: ${payload.webhookSource}/${payload.webhookEvent}`);
+        await redis.xadd(STREAM_MESSAGES, 'MAXLEN', '~', MAX_STREAM_LEN, '*',
+          'payload', JSON.stringify(payload),
+        );
+      },
+    })
+  : null;
+
+const dashboard = createDashboard(character, null, { webhookHandler });
 
 // Subscribe to worker dashboard events
 const redisSub = new Redis(redisUrl);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { createAgent } from './agent.js';
 import { createMemory } from './memory.js';
 import { createDashboard } from './dashboard/server.js';
 import { connectMcpServers } from './mcp.js';
+import { createWebhookHandler } from './webhook.js';
 
 const character = loadCharacter();
 
@@ -25,7 +26,32 @@ if (!process.env.ANTHROPIC_API_KEY) {
 const memory = await createMemory();
 const mcpClients = await connectMcpServers(character.mcpServers);
 const agent = createAgent(character, memory, mcpClients);
-const dashboard = createDashboard(character, memory);
+
+// Webhook handler for single-process mode
+const webhookHandler = Object.keys(character.webhooks || {}).length > 0
+  ? createWebhookHandler(character, {
+      processDirectly: async (payload) => {
+        const response = await agent.process(payload.messageContent, {
+          userId: payload.authorId,
+          userName: payload.authorName,
+          channelId: payload.channelId,
+          threadId: payload.threadId,
+          attachments: [],
+        }, dashboard);
+        // Post to Discord webhook if configured
+        const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+        if (webhookUrl && response.trim()) {
+          await fetch(webhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username: character.name, content: response.slice(0, 2000) }),
+          });
+        }
+      },
+    })
+  : null;
+
+const dashboard = createDashboard(character, memory, { webhookHandler });
 if (mcpClients.serverStatus) dashboard.setMcpStatus(mcpClients.serverStatus);
 
 client.once('ready', () => {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,0 +1,133 @@
+import { createHmac } from 'crypto';
+
+/**
+ * Verify GitHub webhook signature (HMAC-SHA256).
+ */
+function verifySignature(payload, signature, secret) {
+  if (!secret || !signature) return !secret; // No secret configured = skip verification
+  const expected = 'sha256=' + createHmac('sha256', secret).update(payload).digest('hex');
+  return signature === expected;
+}
+
+/**
+ * Format a GitHub webhook event into a concise prompt for the agent.
+ */
+function formatGitHubEvent(event, body) {
+  const repo = body.repository?.full_name || 'unknown';
+
+  switch (event) {
+    case 'pull_request': {
+      const pr = body.pull_request;
+      const action = body.action; // opened, closed, reopened, synchronize, review_requested, etc.
+      return `GitHub webhook: PR ${action} — ${repo}#${pr.number} "${pr.title}" by ${pr.user.login}. State: ${pr.state}, draft: ${pr.draft}, mergeable: ${pr.mergeable_state || 'unknown'}. URL: ${pr.html_url}`;
+    }
+    case 'pull_request_review': {
+      const pr = body.pull_request;
+      const review = body.review;
+      return `GitHub webhook: PR review ${review.state} — ${repo}#${pr.number} "${pr.title}" reviewed by ${review.user.login}. Review state: ${review.state}. URL: ${pr.html_url}`;
+    }
+    case 'check_suite':
+    case 'check_run': {
+      const check = body.check_run || body.check_suite;
+      const prs = (check.pull_requests || []).map(p => `#${p.number}`).join(', ');
+      return `GitHub webhook: CI ${check.status}/${check.conclusion || 'pending'} — ${repo} ${check.name || ''} for PRs ${prs || 'none'}. URL: ${check.html_url}`;
+    }
+    case 'issues': {
+      const issue = body.issue;
+      return `GitHub webhook: Issue ${body.action} — ${repo}#${issue.number} "${issue.title}" by ${issue.user.login}. Labels: ${issue.labels.map(l => l.name).join(', ') || 'none'}. Assignees: ${issue.assignees.map(a => a.login).join(', ') || 'none'}. URL: ${issue.html_url}`;
+    }
+    case 'issue_comment': {
+      const issue = body.issue;
+      const comment = body.comment;
+      const isPR = !!issue.pull_request;
+      return `GitHub webhook: Comment on ${isPR ? 'PR' : 'issue'} ${repo}#${issue.number} "${issue.title}" by ${comment.user.login}: "${comment.body.slice(0, 200)}". URL: ${comment.html_url}`;
+    }
+    case 'push': {
+      const commits = body.commits || [];
+      const branch = body.ref?.replace('refs/heads/', '') || 'unknown';
+      return `GitHub webhook: Push to ${repo}/${branch} — ${commits.length} commit(s) by ${body.pusher?.name || 'unknown'}. Head: ${body.head_commit?.message?.slice(0, 100) || 'no message'}`;
+    }
+    default:
+      return `GitHub webhook: ${event} event on ${repo}. Action: ${body.action || 'none'}`;
+  }
+}
+
+/**
+ * Create a webhook handler that processes incoming HTTP webhooks.
+ * Returns a function: handleWebhook(req, res) -> Promise<void>
+ *
+ * In split mode, pass publishToRedis to queue events for workers.
+ * In single mode, pass processDirectly to handle inline.
+ */
+export function createWebhookHandler(character, { publishToRedis, processDirectly, dashboard }) {
+  const webhookConfig = character.webhooks || {};
+
+  return async function handleWebhook(req, res, source) {
+    const config = webhookConfig[source];
+    if (!config) {
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: `Unknown webhook source: ${source}` }));
+      return;
+    }
+
+    // Read body
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const rawBody = Buffer.concat(chunks).toString();
+
+    let body;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      res.writeHead(400);
+      res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      return;
+    }
+
+    // Verify signature
+    const secret = config.secret?.startsWith('env:')
+      ? process.env[config.secret.slice(4)]
+      : config.secret;
+    const signature = req.headers['x-hub-signature-256'];
+
+    if (secret && !verifySignature(rawBody, signature, secret)) {
+      console.warn(`[Webhook] Invalid signature for ${source}`);
+      res.writeHead(401);
+      res.end(JSON.stringify({ error: 'Invalid signature' }));
+      return;
+    }
+
+    // Format event into prompt
+    const event = req.headers['x-github-event'] || 'unknown';
+    const prompt = formatGitHubEvent(event, body);
+    const deliveryId = req.headers['x-github-delivery'] || `wh-${Date.now()}`;
+
+    console.log(`[Webhook] ${source}/${event}: ${prompt.slice(0, 100)}`);
+    if (dashboard) dashboard.addLog('info', `Webhook ${source}/${event}: ${body.repository?.full_name || ''}`);
+
+    // Respond immediately (GitHub expects < 10s response)
+    res.writeHead(200);
+    res.end(JSON.stringify({ ok: true }));
+
+    // Process the event
+    const payload = {
+      messageContent: prompt,
+      authorId: `webhook-${source}`,
+      authorName: `Webhook (${source})`,
+      channelId: 'webhook',
+      threadId: `webhook-${source}`,
+      attachments: [],
+      isDM: false,
+      isWebhook: true,
+      webhookSource: source,
+      webhookEvent: event,
+      webhookDeliveryId: deliveryId,
+    };
+
+    if (publishToRedis) {
+      await publishToRedis(payload);
+    } else if (processDirectly) {
+      await processDirectly(payload);
+    }
+  };
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -133,8 +133,19 @@ while (!shuttingDown) {
             attachments: msg.attachments || [],
           }, dashboard);
 
-          // Send reply directly via Discord REST API
-          await sendDiscordReply(msg.threadId, response, msg.isDM);
+          // Send reply — webhook events go to Discord webhook, messages go to thread
+          if (msg.isWebhook) {
+            const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
+            if (webhookUrl && response.trim()) {
+              await fetch(webhookUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ username: character.name, content: response.slice(0, 2000) }),
+              });
+            }
+          } else {
+            await sendDiscordReply(msg.threadId, response, msg.isDM);
+          }
 
           await redis.xack(STREAM_MESSAGES, GROUP_NAME, id);
           console.log(`[Worker] Replied to ${msg.threadId} (acked ${id})`);


### PR DESCRIPTION
Closes #70

## Summary
Adds `POST /webhook/{source}` endpoint for receiving external events (GitHub webhooks). Events are processed through the agent loop and responses posted to Discord webhook.

## How it works
1. GitHub sends webhook to `https://atl-e.dashecorp.com/webhook/github`
2. Gateway verifies HMAC signature, formats event into a prompt
3. Event published to Redis Stream (same as Discord messages)
4. Worker processes with Claude + MCP tools
5. Response posted to Discord webhook

## Character config
```json
{
  "webhooks": {
    "github": {
      "secret": "env:GITHUB_WEBHOOK_SECRET"
    }
  }
}
```

## Supported GitHub events
pull_request, pull_request_review, check_suite, check_run, issues, issue_comment, push

🤖 Generated with [Claude Code](https://claude.com/claude-code)