### PR TITLE
feat: add workDir support for CLI agent cwd

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -174,11 +174,14 @@ function createCliAgent(character, memory, mcpClients) {
         args.push('--mcp-config', mcpConfigPath);
       }
 
+      // Use character.workDir as the CLI working directory if set
+      const cwd = character.workDir || undefined;
+      if (cwd) console.log(`[Automate-E] CLI cwd: ${cwd}`);
       console.log(`[Automate-E] CLI call: model=${character.llm.model}`);
 
       // Async spawn with periodic progress heartbeats
       const reply = await new Promise((resolve, reject) => {
-        const proc = spawn('claude', args, { env: process.env });
+        const proc = spawn('claude', args, { env: process.env, cwd });
         const timeoutMs = character.llm?.timeoutMs ?? 300_000;
         let stdout = '';
         let startTime = Date.now();


### PR DESCRIPTION
## Summary
- Adds `character.workDir` field that sets the CLI process working directory
- Lets the CLI use local file tools on target repos instead of remote API reads
- iBuild-E was burning 100 turns ($2) exploring via GitHub MCP — now it runs inside the repo

## Test plan
- [x] Without workDir: CLI runs in automate-e dir (existing behavior)
- [x] With workDir: CLI runs in specified directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)