### PR TITLE
feat: per-issue cost tagging in TOKEN_USAGE events

### DIFF
--- a/src/agent/providers/anthropic-sdk.js
+++ b/src/agent/providers/anthropic-sdk.js
@@ -61,6 +61,7 @@ export function createAnthropicSdkAgent(character, memory, mcpClients) {
           inputTokens: usageInfo?.inputTokens ?? 0,
           outputTokens: usageInfo?.outputTokens ?? 0,
           costUsd: usageInfo?.costUsd ?? 0,
+          category: 'chat',
         });
         if (dashboard && usageInfo) {
           dashboard.addLog('info', `LLM: ${usageInfo.inputTokens} in / ${usageInfo.outputTokens} out, $${usageInfo.costUsd.toFixed(4)}`);

--- a/src/agent/providers/claude-cli.js
+++ b/src/agent/providers/claude-cli.js
@@ -6,6 +6,17 @@ import { reportTokenUsage } from '../../conductor.js';
 import { buildCliPrompt, buildSystemPrompt, buildSystemWithFacts } from '../shared.js';
 import { AgentProviderError, toAgentProviderError } from '../provider-error.js';
 
+/**
+ * Extract repo and issue number from CLI output.
+ * Looks for patterns like "ASSIGNMENT: owner/repo#123" in the response text.
+ */
+function extractAssignment(text) {
+  if (!text) return null;
+  const match = text.match(/ASSIGNMENT:\s*(\S+)#(\d+)/);
+  if (match) return { repo: match[1], issueNumber: parseInt(match[2], 10) };
+  return null;
+}
+
 export function createClaudeCliAgent(character, memory) {
   console.log('[Automate-E] Using Claude Code CLI for LLM');
   const systemPrompt = buildSystemPrompt(character);
@@ -68,10 +79,21 @@ export function createClaudeCliAgent(character, memory) {
 
           if (output) {
             const costUsd = output.total_cost_usd || 0;
-            console.log(`[Automate-E] Claude CLI complete: turns=${output.num_turns}, cost=$${costUsd.toFixed(4)}, subtype=${output.subtype}`);
-            reportTokenUsage({ model: character.llm.model, inputTokens: 0, outputTokens: 0, costUsd });
-            if (dashboard) dashboard.addLog('info', `Claude CLI: ${output.num_turns} turn(s), $${costUsd.toFixed(4)}`);
-            resolve(output.result || `CLI ${output.subtype || 'done'}`);
+            const resultText = output.result || '';
+            const assignment = extractAssignment(resultText);
+            const category = assignment ? 'work' : 'idle';
+            console.log(`[Automate-E] Claude CLI complete: turns=${output.num_turns}, cost=$${costUsd.toFixed(4)}, subtype=${output.subtype}, category=${category}${assignment ? `, assignment=${assignment.repo}#${assignment.issueNumber}` : ''}`);
+            reportTokenUsage({
+              model: character.llm.model,
+              inputTokens: 0,
+              outputTokens: 0,
+              costUsd,
+              repo: assignment?.repo,
+              issueNumber: assignment?.issueNumber,
+              category,
+            });
+            if (dashboard) dashboard.addLog('info', `Claude CLI: ${output.num_turns} turn(s), $${costUsd.toFixed(4)}, ${category}`);
+            resolve(resultText || `CLI ${output.subtype || 'done'}`);
             return;
           }
 

--- a/src/conductor.js
+++ b/src/conductor.js
@@ -20,8 +20,9 @@
  * @param {number} opts.costUsd
  * @param {string} [opts.repo]       - Override CONDUCTOR_REPO env var
  * @param {number} [opts.issueNumber] - Override CONDUCTOR_ISSUE_NUMBER env var
+ * @param {string} [opts.category]    - "work" | "idle" | "chat" — cost category
  */
-export function reportTokenUsage({ model, inputTokens, outputTokens, costUsd, repo, issueNumber } = {}) {
+export function reportTokenUsage({ model, inputTokens, outputTokens, costUsd, repo, issueNumber, category } = {}) {
   const conductorBaseUrl = process.env.CONDUCTOR_BASE_URL;
   const agentId = process.env.AGENT_ID;
 
@@ -39,6 +40,7 @@ export function reportTokenUsage({ model, inputTokens, outputTokens, costUsd, re
     inputTokens: inputTokens || 0,
     outputTokens: outputTokens || 0,
     costUsd: costUsd || 0,
+    category: category || '',
   });
 
   fetch(`${conductorBaseUrl}/api/events`, {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { startHeartbeat } from './heartbeat.js';
 import { startTokenRefresh } from './github-token.js';
 import { abortDeviceAuthFlow, resetDeviceAuthCooldown } from './agent/providers/codex-auth.js';
 import { describeProviderState, getConfiguredProviders, setActiveProvider } from './agent/provider-state.js';
-import { fetchAgentOverview } from './conductor.js';
+import { fetchAgentOverview, reportTokenUsage } from './conductor.js';
 import { buildHeartbeatSnapshot } from './agent-heartbeat.js';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -141,6 +141,20 @@ client.once('ready', () => {
           threadId: `cron-${character.name}`,
           attachments: [],
         }, dashboard, onProgress);
+
+        // Extract assignment info for cost tagging
+        const assignmentMatch = response?.match(/ASSIGNMENT:\s*(\S+)#(\d+)/);
+        if (assignmentMatch) {
+          const [, assignedRepo, assignedIssue] = assignmentMatch;
+          dashboard.addLog('info', `Cron: assignment detected — ${assignedRepo}#${assignedIssue}`);
+          // Set env vars so any further reportTokenUsage calls in this cycle pick up the context
+          process.env.CONDUCTOR_REPO = assignedRepo;
+          process.env.CONDUCTOR_ISSUE_NUMBER = assignedIssue;
+        } else {
+          // Clear per-cycle env vars so idle runs aren't misattributed
+          delete process.env.CONDUCTOR_REPO;
+          delete process.env.CONDUCTOR_ISSUE_NUMBER;
+        }
 
         // Only post meaningful responses to Discord (skip idle/empty/generic)
         const isIdle = !response || response.trim().length < 20


### PR DESCRIPTION
## Summary
- Extract `ASSIGNMENT: repo#N` pattern from CLI agent output to tag `reportTokenUsage()` calls with `repo`, `issueNumber`, and `category` (work/idle/chat)
- Add `category` field to TOKEN_USAGE event body in conductor.js
- Cron loop in index.js sets `CONDUCTOR_REPO`/`CONDUCTOR_ISSUE_NUMBER` env vars per cycle for downstream reporting
- Anthropic SDK provider tags usage as `category: 'chat'`

## Test plan
- [ ] Deploy to dev and trigger a cron cycle with an assignment — verify TOKEN_USAGE event includes repo, issueNumber, category=work
- [ ] Trigger an idle cron cycle — verify category=idle, no repo/issueNumber
- [ ] Send a chat message — verify category=chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)