### PR TITLE
chore: add .rig-agent.yaml for rig stack routing

### DIFF
--- a/.rig-agent.yaml
+++ b/.rig-agent.yaml
@@ -1,0 +1,6 @@
+# Rig agent configuration — tells Conductor-E what this repo needs
+stack: node
+tools: []
+testCommand: npm test
+buildCommand: npm run build
+escalate: []


### PR DESCRIPTION
Adds `.rig-agent.yaml` so Conductor-E knows this repo needs the `node` stack.