### PR TITLE
fix: remove charts/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 docs/
 examples/
-charts/
 .git/
 node_modules/


### PR DESCRIPTION
Dockerfile.base copies charts/ but .dockerignore excluded it, causing build failures.