### PR TITLE
fix: add CLAUDE_CODE_OAUTH_TOKEN env var for CLI auth

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}
                   key: anthropic-api-key
+            - name: CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -209,6 +214,11 @@ spec:
                   name: {{ include "automate-e.secretName" . }}
                   key: discord-bot-token
             - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
+            - name: CLAUDE_CODE_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}


### PR DESCRIPTION
Claude Code CLI needs OAuth tokens via CLAUDE_CODE_OAUTH_TOKEN, not ANTHROPIC_API_KEY.