### PR TITLE
fix: advisor MCP SDK schema compatibility

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}
                   key: anthropic-api-key
+            - name: CLAUDE_CODE_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -209,6 +214,11 @@ spec:
                   name: {{ include "automate-e.secretName" . }}
                   key: discord-bot-token
             - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "automate-e.secretName" . }}
+                  key: anthropic-api-key
+            - name: CLAUDE_CODE_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}

--- a/src/mcp-servers/advisor.js
+++ b/src/mcp-servers/advisor.js
@@ -26,6 +26,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { spawn } from 'child_process';
 
 const CLI = process.env.ADVISOR_CLI || 'claude';
@@ -79,7 +80,7 @@ const server = new Server(
   { capabilities: { tools: {} } }
 );
 
-server.setRequestHandler({ method: 'tools/list' }, async () => ({
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
       name: TOOL_NAME,
@@ -112,7 +113,7 @@ server.setRequestHandler({ method: 'tools/list' }, async () => ({
   ],
 }));
 
-server.setRequestHandler({ method: 'tools/call' }, async (request) => {
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (request.params.name !== TOOL_NAME) {
     return { content: [{ type: 'text', text: `Unknown tool: ${request.params.name}` }] };
   }


### PR DESCRIPTION
Updates advisor MCP server to use Zod schema types required by SDK 1.28+.