### PR TITLE
fix: stack Dockerfiles need root for installs

### DIFF
--- a/Dockerfile.dotnet
+++ b/Dockerfile.dotnet
@@ -2,6 +2,8 @@
 # For: conductor-e, backend APIs, C# projects
 FROM ghcr.io/stig-johnny/automate-e:base AS dotnet-agent
 
+USER root
+
 # Install .NET 10 SDK
 RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
     && chmod +x /tmp/dotnet-install.sh \
@@ -14,4 +16,5 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 LABEL rig.stack="dotnet"
 
+USER agent
 CMD ["node", "src/index.js"]

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,6 +2,8 @@
 # For: automate-e, MCP servers, web apps, React, Next.js
 FROM ghcr.io/stig-johnny/automate-e:base AS node-agent
 
+USER root
+
 # Node 22 already in base image
 # Add common dev tools
 RUN npm install -g typescript tsx jest vitest eslint prettier
@@ -9,4 +11,5 @@ RUN npm install -g typescript tsx jest vitest eslint prettier
 # Label for KEDA routing
 LABEL rig.stack="node"
 
+USER agent
 CMD ["node", "src/index.js"]

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -2,6 +2,8 @@
 # For: scripts, ML, data pipelines
 FROM ghcr.io/stig-johnny/automate-e:base AS python-agent
 
+USER root
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv \
     && rm -rf /var/lib/apt/lists/* \
@@ -11,4 +13,5 @@ RUN pip3 install --break-system-packages pytest black ruff
 
 LABEL rig.stack="python"
 
+USER agent
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
Base image now runs as non-root agent. Stack images need root for apt-get/npm/dotnet installs.