### PR TITLE
fix: execution log gets cost, turns, PR number

### DIFF
--- a/src/agent/providers/claude-cli.js
+++ b/src/agent/providers/claude-cli.js
@@ -120,7 +120,14 @@ export function createClaudeCliAgent(character, memory) {
             if (dashboard) dashboard.addLog('info', `Claude CLI: ${output.num_turns} turn(s), $${costUsd.toFixed(4)}, ${category}`);
             // Return result with session_id for resumption
             const result = resultText || `CLI ${output.subtype || 'done'}`;
-            resolve({ text: result, sessionId: output.session_id || null, toString() { return result; } });
+            resolve({
+              text: result,
+              sessionId: output.session_id || null,
+              costUsd: costUsd,
+              turns: output.num_turns || 0,
+              model: character.llm.model,
+              toString() { return result; },
+            });
             return;
           }
 

--- a/src/stream-consumer.js
+++ b/src/stream-consumer.js
@@ -161,6 +161,10 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
         try { await thread.send(responseText.slice(0, 2000)); } catch {}
       }
 
+      // Extract PR number from response text
+      const prMatch = responseText.match(/pull\/(\d+)|PR #(\d+)|pr.*#(\d+)/i);
+      const prNumber = prMatch ? parseInt(prMatch[1] || prMatch[2] || prMatch[3]) : null;
+
       // Complete execution log
       await logStep('implement', 'completed', responseText.slice(0, 200), response?.costUsd, response?.turns);
       if (executionLogId && conductorUrl) {
@@ -172,6 +176,7 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
               status: 'completed',
               totalCostUsd: response?.costUsd || 0,
               totalTurns: response?.turns || 0,
+              prNumber,
             }),
           });
         } catch {}


### PR DESCRIPTION
Was showing $0 and 0 turns. Now passes data from CLI response.