### PR TITLE
fix: build succeeds even if gitops update fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
   update-gitops:
     needs: build-stacks
     if: github.ref == 'refs/heads/main'
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
continue-on-error until RELEASE_PAT gets rig-gitops access. imagePullPolicy: Always handles deploy.