### PR TITLE
fix: retry without session when resume fails

### DIFF
--- a/src/stream-consumer.js
+++ b/src/stream-consumer.js
@@ -138,14 +138,35 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
         console.log(`[Stream] Resuming session ${existingSessionId} for ${repo}#${issueNumber}`);
       }
 
-      const response = await agent.process(prompt, {
-        userId: 'stream-consumer',
-        userName: character.name,
-        channelId: channelId || 'stream',
-        threadId: `stream-${repo}-${issueNumber}`,
-        attachments: [],
-        sessionId: existingSessionId, // passed to CLI agent for --resume
-      }, dashboard);
+      let response;
+      try {
+        response = await agent.process(prompt, {
+          userId: 'stream-consumer',
+          userName: character.name,
+          channelId: channelId || 'stream',
+          threadId: `stream-${repo}-${issueNumber}`,
+          attachments: [],
+          sessionId: existingSessionId,
+        }, dashboard);
+      } catch (retryErr) {
+        // If resume failed, clear session and retry fresh
+        if (existingSessionId) {
+          console.log(`[Stream] Resume failed for ${repo}#${issueNumber} — retrying without session`);
+          try { await redis.del(sessionKey); } catch {}
+
+          const freshPrompt = `You have been assigned: ${repo}#${issueNumber} — ${title}\n\n${assignment.body || ''}${toolContext}\n\nImplement this task. Read the issue on GitHub for full context. Create a feature branch, implement the fix, commit, push, and create a PR with "Closes #${issueNumber}" in the body.`;
+          response = await agent.process(freshPrompt, {
+            userId: 'stream-consumer',
+            userName: character.name,
+            channelId: channelId || 'stream',
+            threadId: `stream-${repo}-${issueNumber}`,
+            attachments: [],
+            sessionId: null, // no resume
+          }, dashboard);
+        } else {
+          throw retryErr; // no session to clear, propagate error
+        }
+      }
 
       // Save session ID for future iterations
       const newSessionId = response?.sessionId;


### PR DESCRIPTION
Clears stale session and retries fresh. No more ghost runs.