### PR TITLE
fix: auth error retry + 60s backoff

### DIFF
--- a/src/agent/providers/claude-cli.js
+++ b/src/agent/providers/claude-cli.js
@@ -101,6 +101,19 @@ export function createClaudeCliAgent(character, memory) {
           try { output = stdout ? JSON.parse(stdout) : null; } catch { output = null; }
 
           if (output) {
+            // Detect auth/rate-limit errors — throw so stream consumer can retry
+            if (output.is_error && output.result) {
+              const errLower = output.result.toLowerCase();
+              if (errLower.includes('invalid api key') || errLower.includes('rate limit') || errLower.includes('overloaded')) {
+                console.error(`[Automate-E] CLI auth/rate error: ${output.result}`);
+                reject(new AgentProviderError('claude-cli', output.result, {
+                  userMessage: `Claude API error: ${output.result}. Will retry.`,
+                  retryable: true,
+                }));
+                return;
+              }
+            }
+
             const costUsd = output.total_cost_usd || 0;
             const resultText = output.result || '';
             const assignment = extractAssignment(resultText);

--- a/src/stream-consumer.js
+++ b/src/stream-consumer.js
@@ -138,14 +138,35 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
         console.log(`[Stream] Resuming session ${existingSessionId} for ${repo}#${issueNumber}`);
       }
 
-      const response = await agent.process(prompt, {
-        userId: 'stream-consumer',
-        userName: character.name,
-        channelId: channelId || 'stream',
-        threadId: `stream-${repo}-${issueNumber}`,
-        attachments: [],
-        sessionId: existingSessionId, // passed to CLI agent for --resume
-      }, dashboard);
+      let response;
+      try {
+        response = await agent.process(prompt, {
+          userId: 'stream-consumer',
+          userName: character.name,
+          channelId: channelId || 'stream',
+          threadId: `stream-${repo}-${issueNumber}`,
+          attachments: [],
+          sessionId: existingSessionId,
+        }, dashboard);
+      } catch (retryErr) {
+        // If resume failed, clear session and retry fresh
+        if (existingSessionId) {
+          console.log(`[Stream] Resume failed for ${repo}#${issueNumber} — retrying without session`);
+          try { await redis.del(sessionKey); } catch {}
+
+          const freshPrompt = `You have been assigned: ${repo}#${issueNumber} — ${title}\n\n${assignment.body || ''}${toolContext}\n\nImplement this task. Read the issue on GitHub for full context. Create a feature branch, implement the fix, commit, push, and create a PR with "Closes #${issueNumber}" in the body.`;
+          response = await agent.process(freshPrompt, {
+            userId: 'stream-consumer',
+            userName: character.name,
+            channelId: channelId || 'stream',
+            threadId: `stream-${repo}-${issueNumber}`,
+            attachments: [],
+            sessionId: null, // no resume
+          }, dashboard);
+        } else {
+          throw retryErr; // no session to clear, propagate error
+        }
+      }
 
       // Save session ID for future iterations
       const newSessionId = response?.sessionId;

--- a/src/stream-consumer.js
+++ b/src/stream-consumer.js
@@ -298,6 +298,14 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
 
       delete process.env.CONDUCTOR_REPO;
       delete process.env.CONDUCTOR_ISSUE_NUMBER;
+
+      // Wait before retry to avoid hammering API on auth/rate errors
+      const isRetryable = err.retryable || err.message?.includes('Invalid API key') || err.message?.includes('rate limit');
+      if (isRetryable) {
+        console.log(`[Stream] Retryable error — waiting 60s before retry`);
+        await new Promise(r => setTimeout(r, 60_000));
+      }
+
       return; // Don't ACK — retry later
     }
 


### PR DESCRIPTION
Detects Invalid API key/rate limit from CLI. Throws instead of resolving. Stream consumer waits 60s before retry.