### PR TITLE
fix: use CLAUDE_CODE_OAUTH_TOKEN only, remove ANTHROPIC_API_KEY

### DIFF
--- a/charts/automate-e/templates/deployment.yaml
+++ b/charts/automate-e/templates/deployment.yaml
@@ -47,11 +47,6 @@ spec:
                   name: {{ include "automate-e.secretName" . }}
                   key: slack-app-token
             {{- end }}
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "automate-e.secretName" . }}
-                  key: anthropic-api-key
             - name: CLAUDE_CODE_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -213,11 +208,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "automate-e.secretName" . }}
                   key: discord-bot-token
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "automate-e.secretName" . }}
-                  key: anthropic-api-key
             - name: CLAUDE_CODE_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -297,7 +287,7 @@ spec:
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["node", "src/run-once.js"]
               env:
-                - name: ANTHROPIC_API_KEY
+                - name: CLAUDE_CODE_OAUTH_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: {{ include "automate-e.secretName" . }}


### PR DESCRIPTION
## Summary

Root cause of all "Invalid API key" failures on Dev-E.

The Helm chart set both `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` to the same OAuth token. The CLI checks `ANTHROPIC_API_KEY` first and sends it to the Messages API as a regular key → rejected because OAuth tokens aren't API keys.

Fix: only set `CLAUDE_CODE_OAUTH_TOKEN`. API key auth available via `extraEnv` if needed.

## Test plan

- [x] Removed ANTHROPIC_API_KEY from deployment via kubectl, Dev-E runs successfully
- [ ] Verify Helm chart deploys correctly with only CLAUDE_CODE_OAUTH_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)