### PR TITLE
feat: single LLM provider, no fallbacks

### DIFF
--- a/src/agent.test.js
+++ b/src/agent.test.js
@@ -16,64 +16,35 @@ import {
   startDeviceAuthCooldownForTest,
 } from './agent/providers/codex-auth.js';
 
-test('resolveAgentProvider defaults to anthropic', () => {
-  delete process.env.CODEX_CLI_MODE;
-  delete process.env.CLAUDE_CLI_MODE;
-  delete process.env.ANTHROPIC_API_KEY;
-
-  const provider = resolveAgentProvider({ llm: { provider: 'anthropic' } });
-  assert.equal(provider, 'anthropic');
-});
-
-test('resolveAgentProvider uses claude-cli for OAuth subscription tokens', () => {
-  delete process.env.CODEX_CLI_MODE;
-  delete process.env.CLAUDE_CLI_MODE;
-  process.env.ANTHROPIC_API_KEY = 'sk-ant-oat-example';
-
-  const provider = resolveAgentProvider({ llm: { provider: 'anthropic' } });
+test('resolveAgentProvider returns configured provider', () => {
+  const provider = resolveAgentProvider({ llm: { provider: 'claude-cli' } });
   assert.equal(provider, 'claude-cli');
-
-  delete process.env.ANTHROPIC_API_KEY;
 });
 
-test('resolveAgentProvider respects explicit codex-cli provider', () => {
-  delete process.env.CODEX_CLI_MODE;
-  delete process.env.CLAUDE_CLI_MODE;
-  delete process.env.ANTHROPIC_API_KEY;
-
-  const provider = resolveAgentProvider({ llm: { provider: 'codex-cli' } });
-  assert.equal(provider, 'codex-cli');
+test('resolveAgentProvider throws when no provider configured', () => {
+  assert.throws(() => resolveAgentProvider({ llm: {} }), /No LLM provider configured/);
+  assert.throws(() => resolveAgentProvider({}), /No LLM provider configured/);
 });
 
-test('resolveAgentProvider respects explicit openai-api provider', () => {
-  delete process.env.CODEX_CLI_MODE;
-  delete process.env.CLAUDE_CLI_MODE;
-  delete process.env.ANTHROPIC_API_KEY;
-
-  const provider = resolveAgentProvider({ llm: { provider: 'openai-api' } });
-  assert.equal(provider, 'openai-api');
+test('resolveAgentProvider returns any valid provider string', () => {
+  assert.equal(resolveAgentProvider({ llm: { provider: 'codex-cli' } }), 'codex-cli');
+  assert.equal(resolveAgentProvider({ llm: { provider: 'openai-api' } }), 'openai-api');
+  assert.equal(resolveAgentProvider({ llm: { provider: 'anthropic' } }), 'anthropic');
 });
 
-test('buildProviderChain keeps primary provider first and appends fallbacks', () => {
+test('buildProviderChain returns single-element array', () => {
+  const chain = buildProviderChain({ llm: { provider: 'claude-cli' } });
+  assert.deepEqual(chain, ['claude-cli']);
+});
+
+test('buildProviderChain ignores fallbackProviders', () => {
   const chain = buildProviderChain({
     llm: {
-      provider: 'codex-cli',
-      fallbackProviders: ['claude-cli', 'openai-api', 'anthropic'],
+      provider: 'claude-cli',
+      fallbackProviders: ['codex-cli', 'openai-api'],
     },
   });
-
-  assert.deepEqual(chain, ['codex-cli', 'claude-cli', 'openai-api', 'anthropic']);
-});
-
-test('buildProviderChain deduplicates duplicate providers', () => {
-  const chain = buildProviderChain({
-    llm: {
-      provider: 'codex-cli',
-      fallbackProviders: ['codex-cli', 'claude-cli', 'claude-cli'],
-    },
-  });
-
-  assert.deepEqual(chain, ['codex-cli', 'claude-cli']);
+  assert.deepEqual(chain, ['claude-cli']);
 });
 
 test('resolveCharacterForProvider applies provider-specific llm overrides', () => {
@@ -96,7 +67,7 @@ test('resolveCharacterForProvider applies provider-specific llm overrides', () =
   assert.equal(character.llm.timeoutMs, 2000);
 });
 
-test('provider state defaults to the configured primary provider', () => {
+test('provider state defaults to the configured provider', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automate-e-provider-'));
   const previousHome = process.env.HOME;
   const previousCodexHome = process.env.CODEX_HOME;
@@ -104,67 +75,9 @@ test('provider state defaults to the configured primary provider', () => {
   delete process.env.CODEX_HOME;
 
   try {
-    const character = {
-      llm: {
-        provider: 'codex-cli',
-        fallbackProviders: ['claude-cli', 'openai-api'],
-      },
-    };
-
-    assert.equal(getActiveProvider(character), 'codex-cli');
-    assert.match(describeProviderState(character), /Active provider: codex-cli/);
-  } finally {
-    process.env.HOME = previousHome;
-    process.env.CODEX_HOME = previousCodexHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-});
-
-test('provider state can be switched to another configured provider', () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automate-e-provider-'));
-  const previousHome = process.env.HOME;
-  const previousCodexHome = process.env.CODEX_HOME;
-  process.env.HOME = tempDir;
-  delete process.env.CODEX_HOME;
-
-  try {
-    const character = {
-      llm: {
-        provider: 'codex-cli',
-        fallbackProviders: ['claude-cli', 'openai-api'],
-      },
-    };
-
-    assert.equal(setActiveProvider(character, 'claude-cli'), 'claude-cli');
+    const character = { llm: { provider: 'claude-cli' } };
     assert.equal(getActiveProvider(character), 'claude-cli');
-  } finally {
-    process.env.HOME = previousHome;
-    process.env.CODEX_HOME = previousCodexHome;
-    fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-});
-
-test('provider state accepts human-friendly provider aliases', () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automate-e-provider-'));
-  const previousHome = process.env.HOME;
-  const previousCodexHome = process.env.CODEX_HOME;
-  process.env.HOME = tempDir;
-  delete process.env.CODEX_HOME;
-
-  try {
-    const character = {
-      llm: {
-        provider: 'codex-cli',
-        fallbackProviders: ['claude-cli', 'openai-api'],
-      },
-    };
-
-    assert.equal(setActiveProvider(character, 'claude'), 'claude-cli');
-    assert.equal(getActiveProvider(character), 'claude-cli');
-    assert.equal(setActiveProvider(character, 'openai'), 'openai-api');
-    assert.equal(getActiveProvider(character), 'openai-api');
-    assert.equal(setActiveProvider(character, 'codex'), 'codex-cli');
-    assert.equal(getActiveProvider(character), 'codex-cli');
+    assert.match(describeProviderState(character), /Active provider: claude-cli/);
   } finally {
     process.env.HOME = previousHome;
     process.env.CODEX_HOME = previousCodexHome;

--- a/src/agent/provider-chain.js
+++ b/src/agent/provider-chain.js
@@ -1,9 +1,7 @@
 import { resolveAgentProvider } from './provider-mode.js';
 
 export function buildProviderChain(character) {
-  const primary = resolveAgentProvider(character);
-  const configuredFallbacks = normalizeProviderList(character.llm?.fallbackProviders || []);
-  return dedupeProviders([primary, ...configuredFallbacks]);
+  return [resolveAgentProvider(character)];
 }
 
 export function resolveCharacterForProvider(character, provider) {
@@ -16,23 +14,4 @@ export function resolveCharacterForProvider(character, provider) {
       provider,
     },
   };
-}
-
-function normalizeProviderList(value) {
-  return Array.isArray(value)
-    ? value.filter(v => typeof v === 'string' && v.trim())
-    : [];
-}
-
-function dedupeProviders(providers) {
-  const seen = new Set();
-  const result = [];
-
-  for (const provider of providers) {
-    if (seen.has(provider)) continue;
-    seen.add(provider);
-    result.push(provider);
-  }
-
-  return result;
 }

--- a/src/agent/provider-mode.js
+++ b/src/agent/provider-mode.js
@@ -1,15 +1,7 @@
 export function resolveAgentProvider(character) {
-  const configuredProvider = character.llm?.provider || 'anthropic';
-
-  if (process.env.CODEX_CLI_MODE === 'true') return 'codex-cli';
-  if (process.env.CLAUDE_CLI_MODE === 'true') return 'claude-cli';
-  if (configuredProvider === 'openai-api') return 'openai-api';
-
-  if (configuredProvider === 'codex-cli') return 'codex-cli';
-  if (configuredProvider === 'claude-cli') return 'claude-cli';
-
-  const anthropicApiKey = process.env.ANTHROPIC_API_KEY || '';
-  if (anthropicApiKey.startsWith('sk-ant-oat')) return 'claude-cli';
-
-  return 'anthropic';
+  const provider = character.llm?.provider;
+  if (!provider) {
+    throw new Error('No LLM provider configured. Set character.llm.provider in values (e.g., "claude-cli").');
+  }
+  return provider;
 }

--- a/src/stream-consumer.js
+++ b/src/stream-consumer.js
@@ -67,8 +67,8 @@ export function createStreamConsumer(character, agent, dashboard, discordClient)
       }
     }
 
-    // Clear KEDA signal list (tells KEDA we're processing the work)
-    try { await redis.del(`signal:${agentId}`); } catch {}
+    // Pop one signal from KEDA list (don't delete entire list — other assignments may be pending)
+    try { await redis.lpop(`signal:${agentId}`); } catch {}
 
     // Create execution log in Conductor-E
     const conductorUrl = process.env.CONDUCTOR_BASE_URL || process.env.CONDUCTOR_URL;


### PR DESCRIPTION
## Summary

- One AI method at a time, no fallback chain
- Provider must be explicitly set in `character.llm.provider`
- No more env var auto-detection (`CODEX_CLI_MODE`, `CLAUDE_CLI_MODE`, `ANTHROPIC_API_KEY` sniffing)
- To switch AI tool: update the GitOps HelmRelease values
- Also fixes KEDA signal bug: `lpop` instead of `del` so pending assignments aren't lost

## What changes

| Before | After |
|--------|-------|
| Chain: `[claude-cli, codex-cli]` with auto-fallback | Single: `[claude-cli]` only |
| Env vars override character config | Character config is the source of truth |
| `fallbackProviders` in values | Ignored (can be removed from GitOps) |

## Test plan

- [x] 14/14 tests pass
- [x] Dev-E runs successfully with `provider: claude-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)