### PR TITLE
fix: all providers configured, single active with manual switch

### DIFF
--- a/src/agent.test.js
+++ b/src/agent.test.js
@@ -32,19 +32,23 @@ test('resolveAgentProvider returns any valid provider string', () => {
   assert.equal(resolveAgentProvider({ llm: { provider: 'anthropic' } }), 'anthropic');
 });
 
-test('buildProviderChain returns single-element array', () => {
+test('buildProviderChain returns primary when no extra providers configured', () => {
   const chain = buildProviderChain({ llm: { provider: 'claude-cli' } });
   assert.deepEqual(chain, ['claude-cli']);
 });
 
-test('buildProviderChain ignores fallbackProviders', () => {
+test('buildProviderChain includes all configured providers from providers map', () => {
   const chain = buildProviderChain({
     llm: {
       provider: 'claude-cli',
-      fallbackProviders: ['codex-cli', 'openai-api'],
+      providers: {
+        'claude-cli': { model: 'sonnet' },
+        'codex-cli': { model: 'gpt-5.4' },
+        'openai-api': { model: 'gpt-4o' },
+      },
     },
   });
-  assert.deepEqual(chain, ['claude-cli']);
+  assert.deepEqual(chain, ['claude-cli', 'codex-cli', 'openai-api']);
 });
 
 test('resolveCharacterForProvider applies provider-specific llm overrides', () => {

--- a/src/agent/provider-chain.js
+++ b/src/agent/provider-chain.js
@@ -1,7 +1,14 @@
 import { resolveAgentProvider } from './provider-mode.js';
 
+/**
+ * Returns all configured providers. The first is the default (from character.llm.provider).
+ * Additional providers come from character.llm.providers keys.
+ * Only ONE runs at a time — controlled by provider-state.js.
+ */
 export function buildProviderChain(character) {
-  return [resolveAgentProvider(character)];
+  const primary = resolveAgentProvider(character);
+  const additional = Object.keys(character.llm?.providers || {}).filter(p => p !== primary);
+  return [primary, ...additional];
 }
 
 export function resolveCharacterForProvider(character, provider) {


### PR DESCRIPTION
## Summary

Follows up on #146. All providers stay configured in GitOps values (available for switching), but only one runs at a time. No auto-fallback.

- `buildProviderChain` reads from `character.llm.providers` keys
- `setActiveProvider` validates against configured providers
- Discord: `use:claude` / `use:codex` to switch at runtime
- GitOps: change `character.llm.provider` for default

## Test plan

- [x] 14/14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)